### PR TITLE
Add trip editor improvements: type recognition, horizontal scroll, responsive design

### DIFF
--- a/STORIES.md
+++ b/STORIES.md
@@ -1,0 +1,101 @@
+# User Stories - trips/edit
+
+## Completed
+
+### 1. Activity Type Recognition
+- **Status**: Done
+- Auto-classify locations (Museum, Restaurant, Park, etc.) from Google Places API
+- Added `getBestPlaceType()` in JS and `humanize_place_type()` helper in Ruby
+
+### 2. Horizontal Scroll for Multi-Day Trips
+- **Status**: Done
+- Drag/scroll functionality for day columns
+- Gradient fade indicator when more days exist
+- Touch support for mobile
+
+### 3. Responsive Design Overhaul
+- **Status**: Done
+- Mobile tabs: Plan | Days | Map
+- Panels hidden/shown based on active tab on mobile
+
+### 4. Bug Fixes
+- **Status**: Done
+- Fixed map markers not updating (partial format issue)
+- Fixed activity title not updating on subsequent searches
+- Fixed JS scope issue with checkOverflow function
+
+---
+
+## Backlog - Frontend (Trello-like Experience)
+
+### F1. Optimistic UI Updates
+- Update UI immediately when dragging activities
+- Show subtle "saving..." indicator
+- Rollback only if server fails
+- **Priority**: High
+
+### F2. Inline Editing
+- Click on activity title/description to edit directly in card
+- Use contenteditable or inline input fields
+- Save on blur or Enter key
+- **Priority**: Medium
+
+### F3. Keyboard Shortcuts
+- `N` - Add new activity
+- `Esc` - Cancel current action
+- Arrow keys - Navigate between cards
+- `Enter` - Open activity details
+- **Priority**: Low
+
+### F4. Better Drag Visual Feedback
+- Ghost/placeholder showing where card will land
+- Highlight target day column on hover
+- Animate cards shifting to make room
+- **Priority**: High
+
+### F5. Undo/Redo
+- History stack of actions
+- Toast notification: "Activity moved" with Undo button (5s timeout)
+- **Priority**: Medium
+
+---
+
+## Backlog - Backend
+
+### B1. WebSocket Real-time Updates (Action Cable)
+- Real-time sync for collaborators editing same trip
+- Essential for participants feature
+- **Priority**: Medium
+
+### B2. Fix N+1 Queries
+- Use `includes(:trip_day)` for eager loading
+- Profile and optimize slow queries
+- **Priority**: Medium
+
+### B3. API Endpoints for AJAX
+- Proper JSON API for activities CRUD
+- Replace JS.erb responses with JSON
+- **Priority**: Low
+
+### B4. Background Jobs for "Make My Day"
+- Move algorithm to Sidekiq job
+- Add progress updates
+- **Note**: Algorithm needs to be fixed first - current implementation doesn't make sense
+- **Priority**: Low (blocked)
+
+### B5. Request Debouncing
+- Debounce save requests when rapidly dragging cards
+- Save only after 300ms of no movement
+- **Priority**: Low
+
+---
+
+## Backlog - Sign Up
+
+### S1. Remove Username Field
+- Enlever le champ "Nom d'utilisateur" (username)
+- **Priority**: Medium
+
+### S2. Add CAPTCHA
+- Ajouter un détecteur de robots (reCAPTCHA ou similaire)
+- **Priority**: Medium

--- a/app/assets/javascripts/app/google_maps_autocomplete.js
+++ b/app/assets/javascripts/app/google_maps_autocomplete.js
@@ -86,11 +86,10 @@ function onActivityPlaceChanged() {
   $('#activity_est_lat').val(components.lat);
   $('#activity_est_lon').val(components.lon);
   if (def_title) {
-    if($('#activity_est_title').val() == "") {
-      var categ = components.type.replace("_", " ");
-      categ = categ.charAt(0).toUpperCase() + categ.slice(1)+ " at ";
-      $('#activity_est_title').val(categ + components.name);
-    }
+    // Always update title when a new place is selected
+    var categ = components.type.replace("_", " ");
+    categ = categ.charAt(0).toUpperCase() + categ.slice(1)+ " at ";
+    $('#activity_est_title').val(categ + components.name);
     console.log("by activity")
   }
 }
@@ -154,7 +153,7 @@ function getAddressComponents(place) {
   formatted_address = place.formatted_address;
   name = place.name;
   website = place.website;
-  type = place.types[0];
+  type = getBestPlaceType(place.types);
   place_id = place.place_id;
   lat = place.geometry.location.lat();
   lon = place.geometry.location.lng();
@@ -180,4 +179,37 @@ function getAddressComponents(place) {
     lon: lon,
     object: place
   };
+}
+
+// Find the most specific place type from Google Places API
+// Generic types like "establishment" and "point_of_interest" are deprioritized
+function getBestPlaceType(types) {
+  if (!types || types.length === 0) return 'establishment';
+
+  // Generic types to skip if better ones exist
+  var genericTypes = [
+    'establishment',
+    'point_of_interest',
+    'premise',
+    'street_address',
+    'route',
+    'political',
+    'locality',
+    'sublocality',
+    'administrative_area_level_1',
+    'administrative_area_level_2',
+    'administrative_area_level_3',
+    'country',
+    'postal_code'
+  ];
+
+  // Find first non-generic type
+  for (var i = 0; i < types.length; i++) {
+    if (genericTypes.indexOf(types[i]) === -1) {
+      return types[i];
+    }
+  }
+
+  // Fallback to first type if all are generic
+  return types[0];
 }

--- a/app/assets/stylesheets/models/_trips.scss
+++ b/app/assets/stylesheets/models/_trips.scss
@@ -36,8 +36,72 @@
   margin: 20px;
 }
 
+// Horizontal scroll wrapper for multi-day trips
+.trip-days-scroll-wrapper {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+
+  // Gradient fade on right to indicate more content
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 30px;
+    height: 100%;
+    background: linear-gradient(to right, transparent, rgba(255, 255, 255, 0.9));
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.3s;
+  }
+
+  &.has-scroll::after {
+    opacity: 1;
+  }
+}
+
+.trip-days-scroll-container {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  height: 100%;
+  padding-bottom: 10px;
+  scroll-behavior: smooth;
+  -webkit-overflow-scrolling: touch; // Smooth scrolling on iOS
+
+  // Custom scrollbar styling
+  &::-webkit-scrollbar {
+    height: 8px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: #f1f1f1;
+    border-radius: 4px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: #c1c1c1;
+    border-radius: 4px;
+
+    &:hover {
+      background: #a1a1a1;
+    }
+  }
+}
+
 .trip-day {
-  width: 33%;
+  flex: 0 0 280px; // Fixed width, don't grow or shrink
+  min-width: 280px;
+  max-width: 280px;
+  padding: 0 10px;
+  border-right: 1px solid #eee;
+  overflow-y: auto; // Allow vertical scroll within each day
+
+  &:last-child {
+    border-right: none;
+  }
 }
 
 .trip_descri{
@@ -82,4 +146,89 @@
 .border-bottom{
   border-bottom: 1px solid lightgray;
   padding-bottom: 30px;
+}
+
+// Mobile Tab Navigation
+.mobile-tabs {
+  display: none; // Hidden on desktop
+  background: #f8f9fa;
+  border-bottom: 1px solid #dee2e6;
+  padding: 0;
+  margin: 0;
+  width: 100%;
+
+  @media (max-width: 767px) {
+    display: flex;
+    position: sticky;
+    top: 0;
+    z-index: 100;
+  }
+}
+
+.mobile-tab {
+  flex: 1;
+  padding: 12px 8px;
+  border: none;
+  background: transparent;
+  color: #666;
+  font-size: 14px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border-bottom: 3px solid transparent;
+
+  i {
+    margin-right: 4px;
+  }
+
+  &:hover {
+    background: #e9ecef;
+  }
+
+  &.active {
+    color: #007bff;
+    border-bottom-color: #007bff;
+    background: #fff;
+  }
+}
+
+// Mobile panel visibility
+@media (max-width: 767px) {
+  .mobile-panel {
+    display: none !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    padding: 10px !important;
+
+    &.active {
+      display: block !important;
+    }
+  }
+
+  .trip-edit-wrapper {
+    top: 56px; // Account for navbar
+  }
+
+  .trip-days-scroll-wrapper {
+    height: calc(100vh - 180px) !important;
+  }
+
+  .trip-day {
+    flex: 0 0 85vw;
+    min-width: 85vw;
+    max-width: 85vw;
+  }
+
+  .map_container {
+    height: 300px !important;
+  }
+
+  .other_container {
+    height: auto !important;
+    min-height: 100px;
+  }
+
+  .buttons .row .col-xs-3 {
+    width: 50%;
+    margin-bottom: 8px;
+  }
 }

--- a/app/helpers/activities_helper.rb
+++ b/app/helpers/activities_helper.rb
@@ -1,4 +1,43 @@
 module ActivitiesHelper
+  GOOGLE_TYPE_LABELS = {
+    'restaurant' => 'Restaurant',
+    'cafe' => 'Café',
+    'bar' => 'Bar',
+    'night_club' => 'Night Club',
+    'museum' => 'Museum',
+    'art_gallery' => 'Art Gallery',
+    'church' => 'Church',
+    'hindu_temple' => 'Temple',
+    'mosque' => 'Mosque',
+    'synagogue' => 'Synagogue',
+    'park' => 'Park',
+    'zoo' => 'Zoo',
+    'aquarium' => 'Aquarium',
+    'amusement_park' => 'Amusement Park',
+    'stadium' => 'Stadium',
+    'gym' => 'Gym',
+    'spa' => 'Spa',
+    'hotel' => 'Hotel',
+    'lodging' => 'Lodging',
+    'airport' => 'Airport',
+    'train_station' => 'Train Station',
+    'bus_station' => 'Bus Station',
+    'subway_station' => 'Metro Station',
+    'shopping_mall' => 'Shopping Mall',
+    'store' => 'Store',
+    'bakery' => 'Bakery',
+    'library' => 'Library',
+    'movie_theater' => 'Cinema',
+    'tourist_attraction' => 'Attraction',
+    'point_of_interest' => 'Point of Interest',
+    'establishment' => 'Establishment'
+  }.freeze
+
+  def humanize_place_type(google_category)
+    return 'Place' if google_category.blank?
+    GOOGLE_TYPE_LABELS[google_category] || google_category.titleize.gsub('_', ' ')
+  end
+
   def activity_photo_index_path(activity)
     if activity.photo_url.nil?
       cl_image_path("city2_glimf7.jpg", width: 200, height: 150, crop: :fill)

--- a/app/views/activities/_card_activity_index.html.erb
+++ b/app/views/activities/_card_activity_index.html.erb
@@ -10,7 +10,7 @@
   </div>
   <div class="activity-item-content content-box-text no-padding">
     <div class="left-aligh sm-txt">
-      <p><span class="font-alt">Establishment:</span><%= activity.establishment %></p>
+      <p><span class="font-alt"><%= humanize_place_type(activity.google_category) %>:</span> <%= activity.establishment %></p>
       <p><span class="font-alt">Description:</span><%= activity.short_description(80) %></p>
       <p><span class="font-alt">URL:</span> <a href="<%= activity.url %>" target="_blank"><%= activity.url %></a></p>
       <p><span class="font-alt">Address:</span><%= activity.address %></p>

--- a/app/views/trips/edit.html.erb
+++ b/app/views/trips/edit.html.erb
@@ -4,11 +4,24 @@
 <% @disable_footer = true %>
 <% trip_icons = set_day_icon(@trip.trip_days) %>
 <div class="trip-edit-wrapper">
+  <!-- Mobile Tab Navigation -->
+  <div class="mobile-tabs">
+    <button class="mobile-tab active" data-tab="plan-panel">
+      <i class="fa fa-list"></i> Plan
+    </button>
+    <button class="mobile-tab" data-tab="days-panel">
+      <i class="fa fa-calendar"></i> Days
+    </button>
+    <button class="mobile-tab" data-tab="map-panel">
+      <i class="fa fa-map"></i> Map
+    </button>
+  </div>
+
   <div class="container-fuid heigth100">
     <div class="row-fluid text-center heigth100">
 
       <!-- AUTRES -->
-      <div class="col-xs-8 col-sm-2 heigth100">
+      <div id="plan-panel" class="col-xs-8 col-sm-2 heigth100 mobile-panel active">
       <!-- Activities not assigned + Add new activity module -->
         <p>Unassigned(<%= image_tag trip_icons[0], class: "avatar-mini" %>)</p>
         <div class="row">
@@ -28,26 +41,28 @@
       </div>
 
       <!-- LE VOYAGE JOUR PAR JOUR -->
-      <div class="col-xs-12 col-sm-6 heigth100">
+      <div id="days-panel" class="col-xs-12 col-sm-6 heigth100 mobile-panel">
         <!-- Trip Days and Itiniraries -->
         <p class="font-alt"><%= @trip.title %></p>
-        <div class="row width100 inblock side-brd-grey heigth90">
-          <% @trip.trip_days.each do |td| %>
-            <div class="col-xs-4 inblock trip-day heigth100">
-              <p><%= td.title %>(<%= image_tag trip_icons[td.id], class: "avatar-mini" %>)</p>
-              <div id="grid-<%= td.id %>" class="activity-grid works-hover-w sortable accordion heigth90">
-                <% @trip.activities.where(trip_day: td).order(index: :asc).each do |act| %>
-                  <%= render 'activities/card_activity_index', activity: act %>
-                <% end %>
+        <div class="trip-days-scroll-wrapper heigth90">
+          <div class="trip-days-scroll-container side-brd-grey">
+            <% @trip.trip_days.each do |td| %>
+              <div class="trip-day heigth100">
+                <p><%= td.title %>(<%= image_tag trip_icons[td.id], class: "avatar-mini" %>)</p>
+                <div id="grid-<%= td.id %>" class="activity-grid works-hover-w sortable accordion heigth90">
+                  <% @trip.activities.where(trip_day: td).order(index: :asc).each do |act| %>
+                    <%= render 'activities/card_activity_index', activity: act %>
+                  <% end %>
+                </div>
               </div>
-            </div>
-          <% end %>
+            <% end %>
+          </div>
         </div>
       </div>
       <!-- /LE VOYAGE JOUR PAR JOUR -->
 
       <!-- AUTRES -->
-      <div class="col-xs-12 col-sm-4 heigth100">
+      <div id="map-panel" class="col-xs-12 col-sm-4 heigth100 mobile-panel">
 
         <!-- BOUTONS -->
         <div class="buttons margined" style="width: 100%;">
@@ -96,6 +111,95 @@
     $(document).ready(function() {
       // TODO Check safety!!!
       var AUTH_TOKEN = $('meta[name=csrf-token]').attr('content');
+
+      // Horizontal drag-to-scroll for trip days
+      var scrollContainer = document.querySelector('.trip-days-scroll-container');
+      var scrollWrapper = document.querySelector('.trip-days-scroll-wrapper');
+
+      // Check if content overflows and add indicator class (defined outside if block for scope)
+      function checkOverflow() {
+        if (scrollContainer && scrollWrapper) {
+          if (scrollContainer.scrollWidth > scrollContainer.clientWidth) {
+            scrollWrapper.classList.add('has-scroll');
+          } else {
+            scrollWrapper.classList.remove('has-scroll');
+          }
+        }
+      }
+
+      if (scrollContainer) {
+        var isDown = false;
+        var startX;
+        var scrollLeft;
+
+        checkOverflow();
+        window.addEventListener('resize', checkOverflow);
+
+        // Mouse drag scrolling
+        scrollContainer.addEventListener('mousedown', function(e) {
+          // Don't interfere with activity card dragging
+          if ($(e.target).closest('.activity-item').length) return;
+
+          isDown = true;
+          scrollContainer.style.cursor = 'grabbing';
+          startX = e.pageX - scrollContainer.offsetLeft;
+          scrollLeft = scrollContainer.scrollLeft;
+        });
+
+        scrollContainer.addEventListener('mouseleave', function() {
+          isDown = false;
+          scrollContainer.style.cursor = 'grab';
+        });
+
+        scrollContainer.addEventListener('mouseup', function() {
+          isDown = false;
+          scrollContainer.style.cursor = 'grab';
+        });
+
+        scrollContainer.addEventListener('mousemove', function(e) {
+          if (!isDown) return;
+          e.preventDefault();
+          var x = e.pageX - scrollContainer.offsetLeft;
+          var walk = (x - startX) * 1.5; // Scroll speed multiplier
+          scrollContainer.scrollLeft = scrollLeft - walk;
+        });
+
+        // Set initial cursor style
+        scrollContainer.style.cursor = 'grab';
+      }
+
+      // Mobile Tab Navigation
+      $('.mobile-tab').on('click', function() {
+        var targetPanel = $(this).data('tab');
+
+        // Update active tab
+        $('.mobile-tab').removeClass('active');
+        $(this).addClass('active');
+
+        // Update active panel
+        $('.mobile-panel').removeClass('active');
+        $('#' + targetPanel).addClass('active');
+
+        // Re-check scroll overflow when switching to days panel
+        if (targetPanel === 'days-panel') {
+          setTimeout(checkOverflow, 100);
+        }
+
+        // Trigger map resize when switching to map panel
+        if (targetPanel === 'map-panel' && typeof google !== 'undefined' && window.map) {
+          setTimeout(function() {
+            google.maps.event.trigger(window.map, 'resize');
+          }, 100);
+        }
+      });
+
+      // Set initial active panel on mobile
+      if ($(window).width() < 768) {
+        $('.mobile-panel').removeClass('active');
+        $('#days-panel').addClass('active');
+        $('.mobile-tab').removeClass('active');
+        $('.mobile-tab[data-tab="days-panel"]').addClass('active');
+      }
 
       // SORTING !!!
       // Define all lists you can connect together

--- a/app/views/trips/map_markers.json.jbuilder
+++ b/app/views/trips/map_markers.json.jbuilder
@@ -4,5 +4,5 @@ json.array! @trip.activities.where.not(lat: nil, lon: nil).order(:trip_day_id, :
   json.lng act.lon
   json.label act.index.to_s
   json.picture act.trip_day.nil? ? trip_hash[0] : trip_hash[act.trip_day.id]
-  json.infowindow raw render '/activities/map_box.html', activity: act
+  json.infowindow raw render(partial: 'activities/map_box', formats: [:html], locals: { activity: act })
 end


### PR DESCRIPTION
## Summary
- **Activity type recognition**: Auto-classify places from Google Places API (Museum, Restaurant, Park, etc.) instead of always showing "Establishment"
- **Horizontal scroll**: Multi-day trips now support horizontal scrolling with drag-to-scroll and touch support
- **Mobile responsive design**: Added Plan/Days/Map tabs for mobile, panels show/hide based on selection
- **Bug fixes**: Map markers now update correctly, activity title updates on subsequent searches

## Changes
| File | Changes |
|------|---------|
| `google_maps_autocomplete.js` | `getBestPlaceType()` to find specific place type, always update title on place selection |
| `_trips.scss` | Scroll wrapper, mobile tabs, responsive breakpoints |
| `activities_helper.rb` | `humanize_place_type()` helper with 30+ place type labels |
| `_card_activity_index.html.erb` | Display humanized place type |
| `edit.html.erb` | Mobile tabs HTML, scroll container, drag-to-scroll JS |
| `map_markers.json.jbuilder` | Fix partial format for HTML rendering |
| `STORIES.md` | Added backlog tracking |

## Test plan
- [ ] Visit /trips/:id/edit on desktop - verify horizontal scroll works
- [ ] Add an activity with a known type (e.g., museum) - verify type displays correctly
- [ ] Search for a place, select it, search again - verify title updates
- [ ] Check map markers appear after adding activity
- [ ] Test on mobile viewport - verify tabs work

🤖 Generated with [Claude Code](https://claude.com/claude-code)