### PR TITLE
Add mobile drag-and-drop support for trip edit page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .bundle
+vendor/bundle/
 log/*.log
 tmp/**/*
 tmp/*

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,6 +1,7 @@
 //= require jquery
 //= require jquery_ujs
 //= require jquery-ui
+//= require jquery.ui.touch-punch.min
 //= require bootstrap-sprockets
 //= require moment
 //= require bootstrap-datetimepicker

--- a/app/assets/stylesheets/models/_trips.scss
+++ b/app/assets/stylesheets/models/_trips.scss
@@ -546,3 +546,81 @@ p .editable-field {
     margin-bottom: 8px;
   }
 }
+
+// Touch support for mobile drag-and-drop
+.activity-item-header {
+  touch-action: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+@media (max-width: 767px) {
+  .activity-grid.sortable {
+    touch-action: pan-y;
+  }
+
+  .activity-item .activity-item-header {
+    min-height: 44px;
+    padding: 10px;
+  }
+
+  .activity-item.ui-sortable-helper {
+    transform: scale(0.95);
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+  }
+
+  .placeholder-highlight {
+    min-height: 80px;
+    border-width: 3px;
+  }
+}
+
+// Mobile Move Action Button
+.mobile-move-action {
+  display: none;
+  margin: 10px 0;
+  text-align: center;
+
+  @media (max-width: 767px) {
+    display: block;
+  }
+
+  .mobile-move-btn {
+    width: 100%;
+    padding: 10px 15px;
+    font-size: 14px;
+    background: #f8f9fa;
+    border: 1px solid #dee2e6;
+
+    &:hover, &:focus { background: #e9ecef; }
+    i { margin-right: 5px; }
+  }
+
+  .mobile-move-dropdown {
+    width: 100%;
+    max-height: 300px;
+    overflow-y: auto;
+
+    .dropdown-header {
+      font-weight: bold;
+      color: #666;
+      padding: 8px 15px;
+      background: #f8f9fa;
+    }
+
+    a {
+      padding: 10px 15px;
+      display: block;
+      color: #333;
+
+      &:hover { background: #e3f2fd; color: #1976d2; }
+      i { margin-right: 8px; width: 16px; text-align: center; }
+    }
+
+    .current-location {
+      background: #e8f5e9;
+      font-weight: bold;
+      &::after { content: ' (current)'; font-size: 11px; color: #666; font-weight: normal; }
+    }
+  }
+}

--- a/app/views/activities/_card_activity_index.html.erb
+++ b/app/views/activities/_card_activity_index.html.erb
@@ -56,6 +56,29 @@
         </span>
       </p>
 
+      <!-- Mobile Move Action -->
+      <div class="mobile-move-action">
+        <div class="dropdown">
+          <button class="btn btn-sm btn-default dropdown-toggle mobile-move-btn"
+                  type="button" data-toggle="dropdown"
+                  data-activity-id="<%= activity.id %>">
+            <i class="fa fa-arrows"></i> Move to...
+            <span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu mobile-move-dropdown">
+            <li class="dropdown-header">Move to Day:</li>
+            <li><a href="#" class="move-to-day" data-day-id="0" data-activity-id="<%= activity.id %>">
+              <i class="fa fa-list"></i> Unassigned (Plan)
+            </a></li>
+            <% activity.trip.trip_days.each do |day| %>
+              <li><a href="#" class="move-to-day" data-day-id="<%= day.id %>" data-activity-id="<%= activity.id %>">
+                <i class="fa fa-calendar"></i> <%= day.title %>
+              </a></li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+
       <h4 class="text-center">
         <%= link_to activity, method: :delete, remote: true, data: {confirm: "Are you sure?"} do %>
           <span class="icon-scissors"></span> Delete

--- a/app/views/trips/edit.html.erb
+++ b/app/views/trips/edit.html.erb
@@ -215,6 +215,8 @@
 
       $( connectable_lists ).sortable({
           connectWith: ".sortable",
+          delay: 150,        // 150ms delay to distinguish tap from drag on mobile
+          distance: 10,      // 10px threshold before drag starts
           placeholder: "placeholder-highlight ui-corner-all",
           handle: ".activity-item-header",
           cancel: ".activity-item-toggle",
@@ -771,6 +773,90 @@
         if (!$(e.target).closest('.editable-field, a, button, input, select').length) {
           selectCard($(this));
         }
+      });
+
+      // =====================
+      // MOBILE MOVE FUNCTIONALITY
+      // =====================
+
+      // Highlight current location when dropdown opens
+      $(document).on('show.bs.dropdown', '.mobile-move-action .dropdown', function() {
+        var $card = $(this).closest('.activity-item');
+        var currentDayId = $card.closest('.activity-grid').attr('id').split('-').pop();
+        $(this).find('.move-to-day').removeClass('current-location');
+        $(this).find('.move-to-day[data-day-id="' + currentDayId + '"]').addClass('current-location');
+      });
+
+      // Handle move-to-day click
+      $(document).on('click', '.move-to-day', function(e) {
+        e.preventDefault();
+        var activityId = $(this).data('activity-id');
+        var targetDayId = $(this).data('day-id');
+        var $card = $('#act-' + activityId);
+        var $sourceGrid = $card.closest('.activity-grid');
+        var $targetGrid = $('#grid-' + targetDayId);
+
+        // Don't move if already in target
+        if ($sourceGrid.attr('id') === $targetGrid.attr('id')) {
+          $(this).closest('.dropdown').find('.dropdown-toggle').dropdown('toggle');
+          return;
+        }
+
+        // Store original position for undo
+        var originalParent = $sourceGrid.attr('id');
+        var originalIndex = $card.index();
+
+        // Move card to target (optimistic UI)
+        $targetGrid.append($card);
+
+        // Close dropdown
+        $(this).closest('.dropdown').find('.dropdown-toggle').dropdown('toggle');
+
+        // Calculate new index
+        var newIndex = $targetGrid.children('.activity-item').length;
+
+        // Show saving indicator
+        showToast('Moving activity...', 'saving', false);
+
+        // Save to server
+        $.ajax({
+          type: 'PUT',
+          url: '/activities/' + activityId + '/change_position/',
+          data: {
+            activity: { trip_day_id: targetDayId, index: newIndex },
+            authenticity_token: AUTH_TOKEN
+          },
+          success: function() {
+            // Store action for undo
+            actionHistory.push({
+              activityId: activityId,
+              fromGrid: 'grid-' + targetDayId,
+              fromIndex: newIndex - 1,
+              toGrid: originalParent,
+              toIndex: originalIndex
+            });
+
+            // Show success with undo option
+            showToast('Activity moved', 'success', true, function() {
+              undoLastAction(actionHistory[actionHistory.length - 1]);
+            });
+
+            $('#autoRefresh').click();
+          },
+          error: function() {
+            // Rollback: move item back to original position
+            var $originalGrid = $('#' + originalParent);
+            var items = $originalGrid.children('.activity-item');
+
+            if (originalIndex >= items.length) {
+              $originalGrid.append($card);
+            } else {
+              items.eq(originalIndex).before($card);
+            }
+
+            showToast('Failed to move. Please try again.', 'error', false);
+          }
+        });
       });
     });
   </script>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,16 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161214204527) do
-
+ActiveRecord::Schema[7.1].define(version: 2016_12_14_204527) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -26,8 +25,8 @@ ActiveRecord::Schema.define(version: 20161214204527) do
     t.integer "index"
     t.integer "trip_id"
     t.integer "trip_day_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "main_category_id"
     t.string "google_place_identifier"
     t.string "google_category"
@@ -46,8 +45,8 @@ ActiveRecord::Schema.define(version: 20161214204527) do
     t.string "title"
     t.string "google_title"
     t.integer "main_category_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["main_category_id"], name: "index_categories_on_main_category_id"
   end
 
@@ -57,24 +56,24 @@ ActiveRecord::Schema.define(version: 20161214204527) do
     t.integer "sender_id"
     t.integer "recipient_id"
     t.string "token"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
   end
 
   create_table "main_categories", id: :serial, force: :cascade do |t|
     t.string "title"
     t.string "icon"
     t.string "color"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
   end
 
   create_table "participants", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.integer "trip_id"
     t.string "role"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["trip_id"], name: "index_participants_on_trip_id"
     t.index ["user_id"], name: "index_participants_on_user_id"
   end
@@ -82,8 +81,8 @@ ActiveRecord::Schema.define(version: 20161214204527) do
   create_table "pinned_activities", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.integer "activity_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["activity_id"], name: "index_pinned_activities_on_activity_id"
     t.index ["user_id"], name: "index_pinned_activities_on_user_id"
   end
@@ -92,8 +91,8 @@ ActiveRecord::Schema.define(version: 20161214204527) do
     t.string "title"
     t.date "date"
     t.integer "trip_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["trip_id"], name: "index_trip_days_on_trip_id"
   end
 
@@ -108,8 +107,8 @@ ActiveRecord::Schema.define(version: 20161214204527) do
     t.string "photo"
     t.boolean "public", default: true
     t.integer "user_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "cached_votes_total", default: 0
     t.integer "cached_votes_score", default: 0
     t.integer "cached_votes_up", default: 0
@@ -131,15 +130,15 @@ ActiveRecord::Schema.define(version: 20161214204527) do
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
+    t.datetime "reset_password_sent_at", precision: nil
+    t.datetime "remember_created_at", precision: nil
     t.integer "sign_in_count", default: 0, null: false
-    t.datetime "current_sign_in_at"
-    t.datetime "last_sign_in_at"
+    t.datetime "current_sign_in_at", precision: nil
+    t.datetime "last_sign_in_at", precision: nil
     t.inet "current_sign_in_ip"
     t.inet "last_sign_in_ip"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "username"
     t.string "phone"
     t.string "photo"
@@ -150,7 +149,7 @@ ActiveRecord::Schema.define(version: 20161214204527) do
     t.string "first_name"
     t.string "last_name"
     t.string "token"
-    t.datetime "token_expiry"
+    t.datetime "token_expiry", precision: nil
     t.boolean "admin", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
@@ -164,8 +163,8 @@ ActiveRecord::Schema.define(version: 20161214204527) do
     t.boolean "vote_flag"
     t.string "vote_scope"
     t.integer "vote_weight"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["votable_id", "votable_type", "vote_scope"], name: "index_votes_on_votable_id_and_votable_type_and_vote_scope"
     t.index ["votable_type", "votable_id"], name: "index_votes_on_votable_type_and_votable_id"
     t.index ["voter_id", "voter_type", "vote_scope"], name: "index_votes_on_voter_id_and_voter_type_and_vote_scope"

--- a/vendor/assets/javascripts/jquery.ui.touch-punch.min.js
+++ b/vendor/assets/javascripts/jquery.ui.touch-punch.min.js
@@ -1,0 +1,11 @@
+/*!
+ * jQuery UI Touch Punch 0.2.3
+ *
+ * Copyright 2011–2014, Dave Furfero
+ * Dual licensed under the MIT or GPL Version 2 licenses.
+ *
+ * Depends:
+ *  jquery.ui.widget.js
+ *  jquery.ui.mouse.js
+ */
+!function(a){function f(a,b){if(!(a.originalEvent.touches.length>1)){a.preventDefault();var c=a.originalEvent.changedTouches[0],d=document.createEvent("MouseEvents");d.initMouseEvent(b,!0,!0,window,1,c.screenX,c.screenY,c.clientX,c.clientY,!1,!1,!1,!1,0,null),a.target.dispatchEvent(d)}}if(a.support.touch="ontouchend"in document,a.support.touch){var e,b=a.ui.mouse.prototype,c=b._mouseInit,d=b._mouseDestroy;b._touchStart=function(a){var b=this;!e&&b._mouseCapture(a.originalEvent.changedTouches[0])&&(e=!0,b._touchMoved=!1,f(a,"mouseover"),f(a,"mousemove"),f(a,"mousedown"))},b._touchMove=function(a){e&&(this._touchMoved=!0,f(a,"mousemove"))},b._touchEnd=function(a){e&&(f(a,"mouseup"),f(a,"mouseout"),this._touchMoved||f(a,"click"),e=!1)},b._mouseInit=function(){var b=this;b.element.bind({touchstart:a.proxy(b,"_touchStart"),touchmove:a.proxy(b,"_touchMove"),touchend:a.proxy(b,"_touchEnd")}),c.call(b)},b._mouseDestroy=function(){var b=this;b.element.unbind({touchstart:a.proxy(b,"_touchStart"),touchmove:a.proxy(b,"_touchMove"),touchend:a.proxy(b,"_touchEnd")}),d.call(b)}}}(jQuery);


### PR DESCRIPTION
## Summary
- Add touch event support for drag-and-drop on mobile devices using jQuery UI Touch Punch
- Add CSS touch-action properties and mobile-friendly styling for sortable elements
- Add "Move to Day" dropdown menu as fallback for mobile users
- Update schema.rb for Rails 7.1 compatibility

## Test plan
- [ ] Test drag-and-drop on mobile device (iOS Safari, Android Chrome)
- [ ] Test drag-and-drop in Chrome DevTools mobile emulation with touch enabled
- [ ] Verify "Move to Day" dropdown works on mobile
- [ ] Verify desktop drag-and-drop still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)