### PR TITLE
Fix manage trip page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,107 @@
+# CLAUDE.md - Project Context for Yalla
+
+## Project Overview
+**Yalla** is a trip planning web application built with Ruby on Rails. Users can:
+- Create and organize trips with activities
+- Drag & drop activities between days (Trello-like UX)
+- Collaborate with friends via invitations
+- Find inspiration from public trips
+- Use "Make my day" algorithm for automatic activity sorting
+
+## Tech Stack
+- **Ruby**: 3.2.3
+- **Rails**: 7.1.5
+- **Database**: PostgreSQL
+- **Frontend**: Bootstrap 3, jQuery, jQuery UI (drag & drop)
+- **Authentication**: Devise + OmniAuth (Facebook)
+- **File uploads**: Carrierwave + Cloudinary
+- **Maps**: gmaps4rails, Geocoder
+- **Other**: Figaro (env vars), Kaminari (pagination), acts_as_votable
+
+## Common Commands
+```bash
+# Start server
+bin/rails server
+
+# Console
+bin/rails console
+
+# Run tests
+bin/rails test
+
+# Database
+bin/rails db:migrate
+bin/rails db:seed
+
+# Linting
+bundle exec rubocop
+```
+
+## Project Structure
+```
+app/
+├── controllers/
+│   ├── activities_controller.rb   # CRUD for activities
+│   ├── trips_controller.rb        # Main trip management
+│   ├── trip_days_controller.rb    # Day columns in trips
+│   ├── invites_controller.rb      # Trip invitations
+│   └── participants_controller.rb # Trip collaborators
+├── models/
+│   ├── trip.rb          # Main entity, has_many :trip_days, :activities
+│   ├── trip_day.rb      # Day column, belongs_to :trip
+│   ├── activity.rb      # Individual activity/place
+│   ├── user.rb          # Devise user
+│   ├── participant.rb   # User-Trip join (collaborators)
+│   └── invite.rb        # Pending invitations
+└── views/
+    └── trips/edit.html.erb  # Main trip planning interface
+```
+
+## Key Routes
+- `GET /` - Home page
+- `GET /trips` - List public trips
+- `GET /my_trips` - User's trips
+- `GET /trips/:id/edit` - Main trip planning interface (drag & drop)
+- `PUT /activities/:id/change_position` - AJAX for drag & drop
+- `GET /trips/:id/map_markers.json` - Map markers API
+
+## Database Schema (Key Models)
+- **trips**: title, city, country, lat/lon, photo, public, user_id
+- **trip_days**: title, date, trip_id
+- **activities**: title, description, address, lat/lon, trip_id, trip_day_id, index (position)
+- **participants**: user_id, trip_id, role
+- **invites**: email, trip_id, sender_id, recipient_id, token
+
+## Environment Variables (via Figaro)
+Required in `config/application.yml`:
+- `CLOUDINARY_URL` - Image uploads
+- Facebook OAuth credentials
+- Google Maps API key
+
+## Recent Changes & Learnings
+
+### Deprecation Fixes (Jan 2025)
+- Replaced all `redirect_to :back` with `redirect_back(fallback_location: root_path)` (Rails 5+ deprecation)
+
+### Manage Trip Page Redesign (Jan 2025)
+- Modernized `/trips/:id` show page with card-based layout
+- Added participant avatars, better visual hierarchy
+
+### Cloudinary Configuration
+- Added explicit initializer at `config/initializers/cloudinary.rb`
+
+### Unsplash Photo Search
+- Fixed by stripping country code from search queries
+
+## Code Conventions
+- ERB templates (not Haml/Slim)
+- jQuery for frontend interactivity
+- JS responses (`.js.erb`) for AJAX updates
+- Bootstrap 3 classes for styling
+- I18n support (en, fr, de locales)
+
+## Known Issues / Backlog
+See `STORIES.md` for detailed backlog. Key items:
+- "Make my day" algorithm needs rework
+- N+1 queries in some controllers
+- Consider WebSocket for real-time collaboration

--- a/app/assets/stylesheets/pages/_trips_new.scss
+++ b/app/assets/stylesheets/pages/_trips_new.scss
@@ -540,3 +540,333 @@
     }
   }
 }
+
+// ==========================================
+// Properties Page Specific Styles
+// ==========================================
+
+.form-card-title {
+  font-family: $header-font;
+  font-size: $font-size-lg;
+  font-weight: $font-weight-medium;
+  color: $dark-primary;
+  margin: 0 0 24px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid #e5e7eb;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.mb-20 {
+  margin-bottom: 20px;
+}
+
+.mt-20 {
+  margin-top: 20px;
+}
+
+.current-photo-preview {
+  margin-bottom: 16px;
+  border-radius: 8px;
+  overflow: hidden;
+
+  img {
+    width: 100%;
+    height: auto;
+    display: block;
+  }
+}
+
+// Days List
+.days-list {
+  margin-bottom: 20px;
+}
+
+.day-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  background: #f8f9fa;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  margin-bottom: 8px;
+  transition: all 0.2s ease;
+
+  &:hover {
+    border-color: $dark-accent;
+    background: #fff;
+  }
+}
+
+.day-item-content {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 1;
+}
+
+.day-title-input {
+  border: 1px solid transparent;
+  background: transparent;
+  padding: 6px 10px;
+  font-size: $font-size-base;
+  border-radius: 4px;
+  flex: 1;
+  max-width: 200px;
+  transition: all 0.2s ease;
+
+  &:focus {
+    border-color: $dark-accent;
+    background: #fff;
+    outline: none;
+  }
+
+  &::placeholder {
+    color: $dark-primary;
+    font-weight: $font-weight-medium;
+  }
+}
+
+.day-date {
+  font-size: $font-size-sm;
+  color: #6b7280;
+}
+
+.day-item-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.btn-day-action {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background: #fff;
+  color: #6b7280;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  text-decoration: none;
+
+  &:hover {
+    border-color: $dark-accent;
+    color: $dark-primary;
+  }
+
+  &.btn-day-delete:hover {
+    border-color: #ef4444;
+    color: #ef4444;
+    background: #fef2f2;
+  }
+
+  &.success {
+    border-color: #22c55e;
+    color: #22c55e;
+    background: #f0fdf4;
+  }
+}
+
+// Add Day Section
+.add-day-section {
+  padding-top: 16px;
+  border-top: 1px solid #e5e7eb;
+}
+
+.add-day-form {
+  display: flex;
+  gap: 12px;
+  align-items: flex-end;
+  flex-wrap: wrap;
+
+  @media (max-width: 480px) {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+
+.add-day-inputs {
+  display: flex;
+  gap: 8px;
+  flex: 1;
+
+  .form-control {
+    padding: 10px 12px;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    font-size: $font-size-sm;
+
+    &:focus {
+      border-color: $dark-accent;
+      box-shadow: 0 0 0 3px rgba($dark-accent, 0.1);
+      outline: none;
+    }
+  }
+
+  input[type="text"] {
+    flex: 1;
+    min-width: 120px;
+  }
+
+  input[type="date"] {
+    width: 140px;
+  }
+}
+
+.btn-add-day {
+  padding: 10px 20px;
+  background: $dark-primary;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-family: $header-font;
+  font-size: $font-size-sm;
+  font-weight: $font-weight-medium;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+
+  &:hover {
+    background: $dark-secondary;
+  }
+}
+
+// Participants List
+.participants-list {
+  margin-bottom: 20px;
+}
+
+.participant-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  background: #f8f9fa;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  margin-bottom: 8px;
+}
+
+.participant-info {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 1;
+}
+
+.participant-email {
+  font-size: $font-size-base;
+  color: $dark-primary;
+}
+
+.participant-status {
+  font-size: $font-size-xs;
+  padding: 4px 10px;
+  border-radius: 20px;
+  font-weight: $font-weight-medium;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+
+  &.status-owner {
+    background: rgba($dark-primary, 0.1);
+    color: $dark-primary;
+  }
+
+  &.status-editor {
+    background: #dbeafe;
+    color: #1d4ed8;
+  }
+
+  &.status-pending {
+    background: #fef3c7;
+    color: #b45309;
+  }
+}
+
+.btn-remove-participant {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  color: #9ca3af;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border-radius: 4px;
+
+  &:hover {
+    color: #ef4444;
+    background: #fef2f2;
+  }
+}
+
+// Invite Section
+.invite-section {
+  padding-top: 16px;
+  border-top: 1px solid #e5e7eb;
+}
+
+.invite-form {
+  .invite-input-row {
+    display: flex;
+    gap: 12px;
+
+    .form-control {
+      flex: 1;
+      padding: 10px 12px;
+      border: 1px solid #d1d5db;
+      border-radius: 6px;
+      font-size: $font-size-base;
+
+      &:focus {
+        border-color: $dark-accent;
+        box-shadow: 0 0 0 3px rgba($dark-accent, 0.1);
+        outline: none;
+      }
+    }
+  }
+}
+
+.btn-invite {
+  padding: 10px 24px;
+  background: $dark-primary;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-family: $header-font;
+  font-size: $font-size-sm;
+  font-weight: $font-weight-medium;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+
+  &:hover {
+    background: $dark-secondary;
+  }
+}
+
+// Back Link
+.btn-back-link {
+  display: inline-block;
+  padding: 12px 32px;
+  color: #6b7280;
+  font-family: $header-font;
+  font-size: $font-size-sm;
+  font-weight: $font-weight-medium;
+  text-decoration: none;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  transition: all 0.2s ease;
+
+  &:hover {
+    color: $dark-primary;
+    border-color: $dark-accent;
+    background: rgba($dark-accent, 0.05);
+    text-decoration: none;
+  }
+}

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -52,7 +52,7 @@ class ActivitiesController < ApplicationController
   def update
     if @activity.update(activity_params)
       respond_to do |format|
-        format.html { redirect_to :back, notice: 'Activity was successfully updated.' }
+        format.html { redirect_back(fallback_location: edit_trip_path(@activity.trip), notice: 'Activity was successfully updated.') }
         format.js # <-- will render 'app/views/reviews/update.js.erb'
       end
     else
@@ -74,12 +74,12 @@ class ActivitiesController < ApplicationController
     end
     if @activity.save
       respond_to do |format|
-        format.html { redirect_to :back, notice: 'Activity was successfully added to the trip.' }
+        format.html { redirect_back(fallback_location: edit_trip_path(@activity.trip), notice: 'Activity was successfully added to the trip.') }
         format.js  # <-- will render `app/views/reviews/create.js.erb`
       end
     else
       respond_to do |format|
-        format.html { redirect_to :back, alert: @activity.errors.messages }
+        format.html { redirect_back(fallback_location: edit_trip_path(@activity.trip), alert: @activity.errors.messages) }
         format.js  # <-- idem
       end
     end

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -30,8 +30,9 @@ class InvitesController < ApplicationController
   end
 
   def destroy
+    trip_id = @invite.trip_id
     @invite.destroy
-    redirect_to :back, notice: 'Invitation cancelled for this user.'
+    redirect_back(fallback_location: properties_trip_path(trip_id), notice: 'Invitation cancelled for this user.')
   end
 
   private

--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -2,8 +2,9 @@ class ParticipantsController < ApplicationController
   before_action :set_participant, only: [:destroy]
 
   def destroy
+    trip = @participant.trip
     @participant.destroy
-    redirect_to :back, notice: 'Participant was successfully deleted.'
+    redirect_back(fallback_location: properties_trip_path(trip), notice: 'Participant was successfully deleted.')
   end
 
   private

--- a/app/controllers/trip_days_controller.rb
+++ b/app/controllers/trip_days_controller.rb
@@ -21,7 +21,7 @@ class TripDaysController < ApplicationController
   def create
     @trip_day = @trip.trip_days.build(tripday_params)
     if @trip_day.save
-      redirect_to :back, notice: 'Trip day was successfully created.'
+      redirect_back(fallback_location: properties_trip_path(@trip), notice: 'Trip day was successfully created.')
     else
       render :new
     end
@@ -30,7 +30,7 @@ class TripDaysController < ApplicationController
   def update
     if @trip_day.update(tripday_params)
       respond_to do |format|
-        format.html { redirect_to :back, notice: 'Title was successfully updated.' }
+        format.html { redirect_back(fallback_location: properties_trip_path(@trip_day.trip), notice: 'Title was successfully updated.') }
         format.js # <-- will render 'app/views/reviews/update.js.erb'
       end
     else
@@ -47,8 +47,9 @@ class TripDaysController < ApplicationController
   end
 
   def destroy
+    trip = @trip_day.trip
     @trip_day.destroy
-    redirect_to :back, notice: 'Trip day was successfully deleted.'
+    redirect_back(fallback_location: properties_trip_path(trip), notice: 'Trip day was successfully deleted.')
   end
 
   private

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -109,7 +109,7 @@ class TripsController < ApplicationController
 
   def make_my_day
     if @trip.activities.where.not(lat: nil, lon: nil).length < @trip.trip_days.length * 3
-      redirect_to :back, alert: "Only works with at least #{@trip.trip_days.length * 3} activities"
+      redirect_back(fallback_location: edit_trip_path(@trip), alert: "Only works with at least #{@trip.trip_days.length * 3} activities")
     else
       shortest_trip_days(@trip)
       redirect_to edit_trip_path(@trip), notice: 'Magic has happen, this is the best itinirary!'

--- a/app/views/trips/properties.html.erb
+++ b/app/views/trips/properties.html.erb
@@ -1,149 +1,208 @@
-<!-- WRAPPER -->
-<div class="wrapper">
-
-  <!-- HOME -->
-  <section class="module module-thin bg-dark bg-dark-50" data-background=<%= image_path('trip_background.jpg') %> >
-    <div class="container">
-      <!-- MODULE TITLE -->
-      <div class="row">
-        <div class="col-sm-6 col-sm-offset-3">
-          <h1 class="module-title font-alt align-center"><%= @trip.title %></h1>
-          <div class="module-subtitle font-inc align-center">Edit Trip properties</div>
-        </div>
-      </div>
-      <!-- /MODULE TITLE -->
+<div class="trip-new-page">
+  <!-- Hero Section -->
+  <section class="trip-new-hero">
+    <div class="hero-overlay"></div>
+    <div class="hero-content">
+      <h1><%= @trip.title %></h1>
+      <p>Manage your trip settings</p>
     </div>
-  </section >
-  <!-- /HOME -->
+  </section>
 
+  <!-- Form Section -->
+  <section class="trip-new-form-section">
     <div class="container">
       <div class="row">
-        <div class="col-xs-12 col-sm-6">
-          <!-- PARAMETERS -->
-          <h3>Edit trip caracteristics</h3>
-          <%= simple_form_for @trip, defaults: { input_html: { class: 'form-horizontal' } } do |f| %>
-            <ul>
-            <% @trip.errors.full_messages.each do |message| %>
-              <li><%= message %></li>
+        <!-- Left Column: Trip Details -->
+        <div class="col-xs-12 col-md-6">
+          <div class="trip-form-card">
+            <h2 class="form-card-title">Trip Details</h2>
+
+            <%= simple_form_for @trip, html: { class: 'trip-new-form' } do |f| %>
+              <% if @trip.errors.any? %>
+                <div class="alert alert-danger">
+                  <ul class="mb-0">
+                    <% @trip.errors.full_messages.each do |message| %>
+                      <li><%= message %></li>
+                    <% end %>
+                  </ul>
+                </div>
+              <% end %>
+
+              <div class="form-section">
+                <%= f.input :title,
+                  placeholder: "Trip name",
+                  label: "Trip name",
+                  input_html: { class: 'form-input-lg' }
+                %>
+              </div>
+
+              <div class="form-section">
+                <%= f.input :description,
+                  as: :text,
+                  placeholder: "What's this trip about?",
+                  label: "Description",
+                  input_html: { rows: 3 }
+                %>
+              </div>
+
+              <div class="form-section">
+                <%= f.input :category,
+                  as: :select,
+                  collection: ["Discovery", "Lovers", "Business", "Friends", "Bachelor", "Family", "Cultural"],
+                  include_blank: false,
+                  label: "Trip type"
+                %>
+              </div>
+
+              <div class="form-section">
+                <%= f.input :public,
+                  required: false,
+                  label: "Make this trip public",
+                  hint: "Public trips can be discovered by other travelers"
+                %>
+              </div>
+
+              <div class="form-section">
+                <label class="control-label">Cover photo</label>
+                <% if @trip.photo.present? %>
+                  <div class="current-photo-preview">
+                    <%= cl_image_tag @trip.photo.path, width: 400, height: 200, crop: :fill, class: 'img-responsive' %>
+                  </div>
+                <% end %>
+                <%= f.input :photo, label: false, wrapper: false %>
+                <%= f.input :photo_cache, as: :hidden %>
+              </div>
+
+              <div class="form-section">
+                <%= f.button :submit, "Save Changes", class: "btn-submit" %>
+              </div>
             <% end %>
-            </ul>
-            <%= f.input :title %>
-            <%= f.input :description, as: :text %>
-            <%= f.input :category,
-              as: :radio_buttons,
-              item_wrapper_class: 'radio-inline',
-              collection: ["Discovery", "Lovers", "Business", "Friends", "Bachelor", "Family", "Cultural"]
-              %>
-            <%= f.input :public, required: true, label: "Make your trip public and visible to everyone" %>
-            <%= f.input :photo, label: "Add or change picture of the city" %>
-            <%= f.input :photo_cache, as: :hidden %>
-            <%= f.button :submit %>
-          <% end %>
-          <!-- /PARAMETERS -->
+          </div>
         </div>
 
-        <div class="col-xs-12 col-sm-6">
-          <!-- PARAMETERS -->
-          <h3>Edit column titles</h3>
+        <!-- Right Column: Days & Participants -->
+        <div class="col-xs-12 col-md-6">
+          <!-- Days Management Card -->
+          <div class="trip-form-card mb-20">
+            <h2 class="form-card-title">Trip Days</h2>
 
-          <table class="table table-hover">
-              <colgroup>
-                <col>
-                <col class="align-right">
-              </colgroup>
-            <thead>
-              <tr>
-                <th>Title</th>
-                <th>Edit</th>
-              </tr>
-            </thead>
-            <tbody>
-             <% @trip.trip_days.each do |day| %>
-                <tr>
-                  <td class="text-left">
-                    <input id="trip-day-title-<%= day[:id] %>" placeholder="<%= day[:title] %>" type="text" />
-                  </td>
-                  <td class="text-right">
-                    <button id="btn-trip-day-update-<%= day[:id] %>" type="button" class="btn btn-g btn-sm btn-trip-day-update">update</button>
-                  </td>
-                </tr>
+            <div class="days-list">
+              <% @trip.trip_days.order(:date).each do |day| %>
+                <div class="day-item">
+                  <div class="day-item-content">
+                    <input type="text"
+                           id="trip-day-title-<%= day.id %>"
+                           class="day-title-input"
+                           placeholder="<%= day.title %>"
+                           value="">
+                    <span class="day-date"><%= day.date&.strftime("%a, %b %d") %></span>
+                  </div>
+                  <div class="day-item-actions">
+                    <button type="button"
+                            id="btn-trip-day-update-<%= day.id %>"
+                            class="btn-day-action btn-trip-day-update"
+                            title="Update title">
+                      <i class="fa fa-check"></i>
+                    </button>
+                    <%= link_to trip_trip_day_path(@trip, day),
+                        method: :delete,
+                        data: { confirm: "Delete this day and all its activities?" },
+                        class: "btn-day-action btn-day-delete",
+                        title: "Delete day" do %>
+                      <i class="fa fa-trash"></i>
+                    <% end %>
+                  </div>
+                </div>
               <% end %>
-            </tbody>
-          </table>
+            </div>
 
-          <!-- /PARAMETERS -->
-        </div>
-
-        <div class="col-xs-12 col-sm-6">
-          <!-- USERS AND INVITATIONS -->
-          <h3>Manage and invite participants</h3>
-          <table class="table table-hover">
-              <colgroup>
-                <col>
-                <col class="align-right">
-              </colgroup>
-            <thead>
-              <tr>
-                <th>Email</th>
-                <th>Status</th>
-                <th>Remove?</th>
-              </tr>
-            </thead>
-            <tfoot>
-              <%= simple_form_for @invite do |f| %>
-                <tr class="warning">
-                  <td>
-                    <%= f.input :email, label:false, placeholder: "Participant's email" %>
-                    <%= f.input :trip_id, as: :hidden, input_html: {value: @trip.id} %>
-                  </td>
-                  <td>
-                  </td>
-                  <td>
-                    <%= f.button :submit, "Invite", class: "btn btn-primary" %>
-                  </td>
-                </tr>
+            <!-- Add Day Form -->
+            <div class="add-day-section">
+              <%= form_for [@trip, TripDay.new], html: { class: 'add-day-form' } do |f| %>
+                <div class="add-day-inputs">
+                  <%= f.text_field :title, placeholder: "Day title (e.g. Day 4)", class: 'form-control' %>
+                  <%= f.date_field :date, class: 'form-control', value: (@trip.trip_days.maximum(:date)&.tomorrow || Date.today) %>
+                </div>
+                <%= f.submit "Add Day", class: "btn-add-day" %>
               <% end %>
-            </tfoot>
-            <tbody>
-             <% @trip.all_members.each do |member| %>
-                <tr>
-                  <td class="text-left"><%= member[:email] %></td>
-                  <td class="text-right"><%= member[:status] %></td>
-                  <td class="text-right">
+            </div>
+          </div>
+
+          <!-- Participants Card -->
+          <div class="trip-form-card">
+            <h2 class="form-card-title">Participants</h2>
+
+            <div class="participants-list">
+              <% @trip.all_members.each do |member| %>
+                <div class="participant-item">
+                  <div class="participant-info">
+                    <span class="participant-email"><%= member[:email] %></span>
+                    <span class="participant-status status-<%= member[:status].downcase %>"><%= member[:status] %></span>
+                  </div>
+                  <div class="participant-actions">
                     <% if member[:participant_id] %>
-                      <%= link_to participant_path(member[:participant_id]) , method: :delete, data: {confirm: "are you sure ?"} do %>
-                        <i class="fa fa-trash" aria-hidden="true"></i>
+                      <%= link_to participant_path(member[:participant_id]),
+                          method: :delete,
+                          data: { confirm: "Remove this participant?" },
+                          class: "btn-remove-participant" do %>
+                        <i class="fa fa-times"></i>
                       <% end %>
                     <% elsif member[:invitation_id] %>
-                      <%= link_to invite_path(member[:invitation_id]) , method: :delete, data: {confirm: "are you sure ?"} do %>
-                        <i class="fa fa-trash" aria-hidden="true"></i>
+                      <%= link_to invite_path(member[:invitation_id]),
+                          method: :delete,
+                          data: { confirm: "Cancel this invitation?" },
+                          class: "btn-remove-participant" do %>
+                        <i class="fa fa-times"></i>
                       <% end %>
                     <% end %>
-                  </td>
-                </tr>
+                  </div>
+                </div>
               <% end %>
-            </tbody>
-          </table>
-        <!-- /USERS AND INVITATIONS -->
+            </div>
+
+            <!-- Invite Form -->
+            <div class="invite-section">
+              <%= simple_form_for @invite, html: { class: 'invite-form' } do |f| %>
+                <%= f.input :trip_id, as: :hidden, input_html: { value: @trip.id } %>
+                <div class="invite-input-row">
+                  <%= f.input :email,
+                      label: false,
+                      placeholder: "Enter email to invite",
+                      input_html: { class: 'form-control' },
+                      wrapper: false %>
+                  <%= f.button :submit, "Invite", class: "btn-invite" %>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Back Link -->
+      <div class="row">
+        <div class="col-xs-12 text-center mt-20">
+          <%= link_to "Back to Trip", edit_trip_path(@trip), class: "btn-back-link" %>
         </div>
       </div>
     </div>
+  </section>
 </div>
-
-
 
 <% content_for(:js) do %>
   <script>
     $(document).ready(function() {
-      // TODO Check safety!!!
       var AUTH_TOKEN = $('meta[name=csrf-token]').attr('content');
 
-      $('.btn-trip-day-update').click(function(){
-
+      $('.btn-trip-day-update').click(function() {
         var element_button = $(this);
         var trip_day_id = element_button[0].id.split("-").pop();
-        var element_content = $('#trip-day-title-'+trip_day_id)
-        var trip_day_new_title = element_content[0].value
+        var element_content = $('#trip-day-title-' + trip_day_id);
+        var trip_day_new_title = element_content[0].value;
+
+        if (!trip_day_new_title.trim()) {
+          alert('Please enter a title');
+          return;
+        }
 
         var data = {
           trip_day: {
@@ -158,19 +217,19 @@
           url: '/trip_days/' + trip_day_id + '/update_title',
           data: data,
           success: function(data) {
-            //console.log(data);
-            console.log('trip updated');
-            element_content[0].placeholder = trip_day_new_title
-            element_content[0].value = ''
-            // $('#autoRefresh').click();
-            // callback(data); // return data in callback
+            element_content[0].placeholder = trip_day_new_title;
+            element_content[0].value = '';
+            element_button.addClass('success');
+            setTimeout(function() {
+              element_button.removeClass('success');
+            }, 1500);
           },
           error: function(jqXHR) {
             console.error(jqXHR.responseText);
+            alert('Failed to update title');
           }
         });
       });
     });
   </script>
 <% end %>
-

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -89,4 +89,8 @@ Rails.application.configure do
   # Action mailer configuration (Brevo API)
   config.action_mailer.delivery_method = :brevo_api
   config.action_mailer.default_url_options = { host: "www.justyalla.app" }
+
+  config.hosts << "justyalla.app"
+  config.hosts << "www.justyalla.app"
+
 end


### PR DESCRIPTION
## Summary
- Redesign properties/manage trip page to match modern styling of trip creation page
- Fix broken delete invite functionality (deprecated `redirect_to :back`)
- Add day management UI (add/remove trip days)

## Changes
- **UI Redesign**: Card-based layout with hero section, two-column design for trip details and day/participant management
- **Fix deprecated redirects**: Replace all `redirect_to :back` with `redirect_back(fallback_location: ...)` across:
  - `invites_controller.rb`
  - `trip_days_controller.rb`
  - `participants_controller.rb`
  - `activities_controller.rb`
  - `trips_controller.rb`
- **Day management**: Add/remove days with inline title editing

## Test plan
- [ ] Visit `/trips/:id/properties` and verify new styling
- [ ] Test deleting an invite - should redirect properly
- [ ] Test deleting a participant - should redirect properly
- [ ] Test adding a new day
- [ ] Test removing a day
- [ ] Test updating day title inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)