### PR TITLE
Improve Make My Day algorithm with DBSCAN clustering

### DIFF
--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -108,11 +108,11 @@ class TripsController < ApplicationController
   end
 
   def make_my_day
-    if @trip.activities.where.not(lat: nil, lon: nil).length < @trip.trip_days.length * 3
-      redirect_back(fallback_location: edit_trip_path(@trip), alert: "Only works with at least #{@trip.trip_days.length * 3} activities")
+    result = TripClusteringService.new(@trip).call
+    if result.success?
+      redirect_to edit_trip_path(@trip), notice: "Your itinerary has been optimized!"
     else
-      shortest_trip_days(@trip)
-      redirect_to edit_trip_path(@trip), notice: 'Magic has happen, this is the best itinirary!'
+      redirect_back(fallback_location: edit_trip_path(@trip), alert: result.message)
     end
   end
 
@@ -153,103 +153,5 @@ class TripsController < ApplicationController
         end
       end
     end
-  end
-
-
-  # MAKE MY DAY ALGORITHM
-
-  def shortest_trip_days(trip)
-    points = trip.activities.where.not(lat: nil, lon: nil).map{ |a| {id: a.id, lat: a.lat, lon: a.lon} }
-    shortest_solution = best_path(points, trip.trip_days.length)
-    day_index = 0
-    shortest_solution.each_pair do |key, value|
-      if value.class == Array
-        value.each_with_index do |act, i|
-          activity = Activity.find(act[:id])
-          activity.trip_day_id = trip.trip_days[day_index].id
-          activity.index = i + 1
-          activity.save
-        end
-        day_index += 1
-      end
-    end
-  end
-
-  def best_path(points, days)
-    days = 3
-    possible_trips = all_combinaisons(points, days)
-    shortest = possible_trips.values.min_by { |trip| trip[:distance] }
-  end
-
-  def all_combinaisons(points, days)
-    combos = {}
-    i = 1
-    min_by_day = (points.length / (days + 1)).floor
-    a_max = points.length - min_by_day * (days - 1)
-
-    (min_by_day..a_max).each do |a|
-      points_a = points
-      combos[i] = {} if combos[i].nil?
-      # find which combination of a length is the shortest to only iterate on this one
-      combos[i][:day1] = points_a.combination(a).to_a.min_by { |route| center_distance(route) }
-
-      # TODO: rendre le truc iteratif et repasser dans le code au dessus mais avec le nouveau subpoint
-      # les points d'origine sont en fait le sous ensemble et on le fait sur 2 jours au lieu de 3
-      points_b = points_a - combos[i][:day1]
-      b_max = points_b.length - min_by_day * (days - 2)
-      (min_by_day..b_max).each do |b|
-        if combos[i].nil?
-          combos[i] = {}
-          combos[i][:day1] = combos[i-1][:day1]
-        end
-        # find which combination of b length is the shortest to only iterate on this one
-
-        combos[i][:day2] = points_b.combination(b).to_a.min_by { |route| center_distance(route) }
-
-        # C can only be the remaining!
-        combos[i][:day3] = points_b - combos[i][:day2]
-
-        # TODO: if 4 days or more
-        # points_c = points_b - combos[i][:day2]
-        # c_max = points_c.length
-        # (2..c_max).each do |c|
-        #   if combos[i].nil?
-        #     combos[i][:day1] = combos[i-1][:day1]
-        #     combos[i][:day2] = combos[i-1][:day2]
-        #   end
-        #   combos[i][:day3] = points_c.combination(c).to_a.min_by { |route| center_distance(route) }
-        # end
-
-        # TODO: OPTIMIZE CALCULATION OF PERMUTATION - TOO LONG!
-        # combos[i].each_pair do |key, path|
-        #   if path.length > 9
-        #     combos[i][key] = path.sort { |x,y| y[:lat] <=> x[:lat] }
-        #   else
-        #     combos[i][key] = path.permutation(path.length).to_a.min_by { |route| path_length(route) }
-        #   end
-        # end
-        # PERMUTATIONS
-
-        combos[i][:distance] = path_length(combos[i][:day1]) + path_length(combos[i][:day2]) + path_length(combos[i][:day3])
-        i += 1
-      end
-    end
-    return combos
-  end
-
-  def path_length(points)
-    sum = 0
-    if points.length >= 2
-      points.each_cons(2) do |a, b|
-        sum += Math.sqrt((b[:lat] - a[:lat])**2 + (b[:lon] - a[:lon])**2)
-      end
-    end
-    return sum
-  end
-
-  def center_distance(points)
-    lat_cen = points.inject(0){ |sum, a| sum += a[:lat] } / points.length
-    lon_cen = points.inject(0){ |sum, a| sum += a[:lon] } / points.length
-    points.inject(0) { |sum, a| sum += Math.sqrt((lat_cen - a[:lat])**2 + (lon_cen - a[:lon])**2) }
   end
 end

--- a/app/services/trip_clustering_service.rb
+++ b/app/services/trip_clustering_service.rb
@@ -1,0 +1,303 @@
+class TripClusteringService
+  Result = Struct.new(:success?, :message, keyword_init: true)
+
+  EARTH_RADIUS_KM = 6371.0
+  MIN_POINTS_FOR_DBSCAN = 2
+
+  def initialize(trip)
+    @trip = trip
+  end
+
+  def call
+    days = @trip.trip_days.order(:created_at).to_a
+    return Result.new("success?": false, message: "This trip has no days.") if days.empty?
+
+    activities = @trip.activities.to_a
+    geolocated = activities.select { |a| a.lat.present? && a.lon.present? }
+    ungeolocated = activities - geolocated
+
+    if geolocated.length < days.length
+      return Result.new(
+        "success?": false,
+        message: "Need at least #{days.length} geolocated activities (currently #{geolocated.length})."
+      )
+    end
+
+    if days.length == 1
+      ordered = optimize_route(geolocated)
+      assign_activities(ordered + ungeolocated, [days.first])
+    else
+      clusters = cluster_into_days(geolocated, days.length)
+      clusters.each { |c| c.replace(optimize_route(c)) }
+      distribute_ungeolocated(ungeolocated, clusters)
+      assign_activities_from_clusters(clusters, days)
+    end
+
+    Result.new("success?": true, message: "Your itinerary has been optimized!")
+  end
+
+  private
+
+  # --- Haversine distance in km ---
+
+  def haversine(lat1, lon1, lat2, lon2)
+    dlat = to_rad(lat2 - lat1)
+    dlon = to_rad(lon2 - lon1)
+    a = Math.sin(dlat / 2)**2 +
+        Math.cos(to_rad(lat1)) * Math.cos(to_rad(lat2)) * Math.sin(dlon / 2)**2
+    EARTH_RADIUS_KM * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+  end
+
+  def to_rad(deg)
+    deg * Math::PI / 180.0
+  end
+
+  def activity_distance(a, b)
+    haversine(a.lat, a.lon, b.lat, b.lon)
+  end
+
+  # --- DBSCAN clustering ---
+
+  def cluster_into_days(activities, num_days)
+    return [activities.dup] if num_days == 1
+
+    clusters = dbscan(activities, auto_eps(activities))
+    noise = clusters.delete(:noise) || []
+
+    # Assign noise points to nearest cluster
+    if clusters.any?
+      noise.each { |act| nearest_cluster(act, clusters) << act }
+    else
+      # All noise — treat each activity as its own cluster
+      clusters = activities.map { |a| [object_id, [a]] }.to_h
+      clusters = Hash[activities.each_with_index.map { |a, i| [i, [a]] }]
+    end
+
+    cluster_list = clusters.values
+
+    # Balance to match day count
+    cluster_list = merge_clusters(cluster_list, num_days) while cluster_list.length > num_days
+    cluster_list = split_clusters(cluster_list, num_days) while cluster_list.length < num_days
+
+    cluster_list
+  end
+
+  def auto_eps(activities)
+    return 1.0 if activities.length < MIN_POINTS_FOR_DBSCAN
+
+    distances = []
+    activities.each_with_index do |a, i|
+      ((i + 1)...activities.length).each do |j|
+        distances << activity_distance(a, activities[j])
+      end
+    end
+    distances.sort!
+
+    # 20th percentile of pairwise distances
+    idx = [(distances.length * 0.2).floor, 0].max
+    [distances[idx] || 1.0, 0.5].max
+  end
+
+  def dbscan(activities, eps, min_pts = 2)
+    visited = {}
+    clusters = {}
+    cluster_id = 0
+
+    activities.each do |act|
+      next if visited[act.id]
+      visited[act.id] = true
+
+      neighbors = region_query(act, activities, eps)
+
+      if neighbors.length < min_pts
+        clusters[:noise] ||= []
+        clusters[:noise] << act
+      else
+        cluster_id += 1
+        clusters[cluster_id] = [act]
+        expand_cluster(act, neighbors, clusters, cluster_id, visited, activities, eps, min_pts)
+      end
+    end
+
+    clusters
+  end
+
+  def region_query(act, activities, eps)
+    activities.select { |other| other.id != act.id && activity_distance(act, other) <= eps }
+  end
+
+  def expand_cluster(point, neighbors, clusters, cluster_id, visited, activities, eps, min_pts)
+    queue = neighbors.dup
+    while queue.any?
+      current = queue.shift
+      unless visited[current.id]
+        visited[current.id] = true
+        new_neighbors = region_query(current, activities, eps)
+        queue.concat(new_neighbors) if new_neighbors.length >= min_pts
+      end
+
+      # Add to cluster if not already in one
+      already_clustered = clusters.any? { |k, v| k != :noise && v.include?(current) }
+      unless already_clustered
+        clusters[:noise]&.delete(current)
+        clusters[cluster_id] << current
+      end
+    end
+  end
+
+  def nearest_cluster(activity, clusters)
+    clusters.values.min_by do |cluster|
+      centroid = cluster_centroid(cluster)
+      haversine(activity.lat, activity.lon, centroid[:lat], centroid[:lon])
+    end
+  end
+
+  def cluster_centroid(cluster)
+    {
+      lat: cluster.sum(&:lat) / cluster.length.to_f,
+      lon: cluster.sum(&:lon) / cluster.length.to_f
+    }
+  end
+
+  # --- Merge / Split to match day count ---
+
+  def merge_clusters(clusters, target)
+    return clusters if clusters.length <= target
+
+    # Find two closest clusters by centroid distance and merge them
+    min_dist = Float::INFINITY
+    merge_i = 0
+    merge_j = 1
+
+    clusters.each_with_index do |c1, i|
+      ((i + 1)...clusters.length).each do |j|
+        c2 = clusters[j]
+        cent1 = cluster_centroid(c1)
+        cent2 = cluster_centroid(c2)
+        dist = haversine(cent1[:lat], cent1[:lon], cent2[:lat], cent2[:lon])
+        if dist < min_dist
+          min_dist = dist
+          merge_i = i
+          merge_j = j
+        end
+      end
+    end
+
+    merged = clusters[merge_i] + clusters[merge_j]
+    result = clusters.dup
+    result.delete_at(merge_j)
+    result[merge_i] = merged
+    result
+  end
+
+  def split_clusters(clusters, target)
+    return clusters if clusters.length >= target
+
+    # Split the largest cluster along its widest geographic axis
+    largest_idx = clusters.each_with_index.max_by { |c, _| c.length }[1]
+    cluster = clusters[largest_idx]
+
+    lat_range = cluster.max_by(&:lat).lat - cluster.min_by(&:lat).lat
+    lon_range = cluster.max_by(&:lon).lon - cluster.min_by(&:lon).lon
+
+    sorted = if lat_range >= lon_range
+               cluster.sort_by(&:lat)
+             else
+               cluster.sort_by(&:lon)
+             end
+
+    mid = sorted.length / 2
+    part1 = sorted[0...mid]
+    part2 = sorted[mid..]
+
+    result = clusters.dup
+    result.delete_at(largest_idx)
+    result.push(part1, part2)
+    result
+  end
+
+  # --- Nearest-neighbor TSP + 2-opt ---
+
+  def optimize_route(activities)
+    return activities if activities.length <= 2
+
+    # Nearest-neighbor heuristic
+    route = [activities.first]
+    remaining = activities[1..].dup
+
+    while remaining.any?
+      nearest = remaining.min_by { |a| activity_distance(route.last, a) }
+      route << nearest
+      remaining.delete(nearest)
+    end
+
+    # 2-opt improvement
+    two_opt(route)
+  end
+
+  def two_opt(route)
+    return route if route.length <= 3
+
+    improved = true
+    while improved
+      improved = false
+      (1...(route.length - 1)).each do |i|
+        ((i + 1)...route.length).each do |j|
+          old_dist = segment_distance(route, i, j)
+          new_dist = swap_distance(route, i, j)
+          if new_dist < old_dist
+            route[i..j] = route[i..j].reverse
+            improved = true
+          end
+        end
+      end
+    end
+
+    route
+  end
+
+  def segment_distance(route, i, j)
+    activity_distance(route[i - 1], route[i]) +
+      (j + 1 < route.length ? activity_distance(route[j], route[j + 1]) : 0)
+  end
+
+  def swap_distance(route, i, j)
+    activity_distance(route[i - 1], route[j]) +
+      (j + 1 < route.length ? activity_distance(route[i], route[j + 1]) : 0)
+  end
+
+  # --- Distribute ungeolocated activities ---
+
+  def distribute_ungeolocated(ungeolocated, clusters)
+    return if ungeolocated.empty?
+
+    ungeolocated.each_with_index do |act, i|
+      clusters[i % clusters.length] << act
+    end
+  end
+
+  # --- Persist assignments ---
+
+  def assign_activities(ordered, days)
+    ActiveRecord::Base.transaction do
+      per_day = (ordered.length.to_f / days.length).ceil
+      ordered.each_slice(per_day).with_index do |group, day_idx|
+        day = days[[day_idx, days.length - 1].min]
+        group.each_with_index do |activity, pos|
+          activity.update!(trip_day_id: day.id, index: pos + 1)
+        end
+      end
+    end
+  end
+
+  def assign_activities_from_clusters(clusters, days)
+    ActiveRecord::Base.transaction do
+      clusters.each_with_index do |cluster, day_idx|
+        day = days[day_idx]
+        cluster.each_with_index do |activity, pos|
+          activity.update!(trip_day_id: day.id, index: pos + 1)
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/cloudinary.rb
+++ b/config/initializers/cloudinary.rb
@@ -1,6 +1,2 @@
-Cloudinary.config do |config|
-  config.cloud_name = ENV['CLOUDINARY_CLOUD_NAME']
-  config.api_key = ENV['CLOUDINARY_API_KEY']
-  config.api_secret = ENV['CLOUDINARY_API_SECRET']
-  config.secure = true
-end
+Cloudinary.config_from_url(ENV['CLOUDINARY_URL']) if ENV['CLOUDINARY_URL']
+Cloudinary.config.secure = true

--- a/test/services/trip_clustering_service_test.rb
+++ b/test/services/trip_clustering_service_test.rb
@@ -1,0 +1,227 @@
+require "test_helper"
+
+class TripClusteringServiceTest < ActiveSupport::TestCase
+  setup do
+    Geocoder.configure(lookup: :test)
+    Geocoder::Lookup::Test.add_stub("Paris, FR", [
+      { "latitude" => 48.8566, "longitude" => 2.3522 }
+    ])
+
+    @user = User.create!(
+      username: "testuser",
+      email: "test@example.com",
+      password: "password123"
+    )
+    @category = MainCategory.create!(title: "Visits", icon: "icon", color: "bg-visites")
+  end
+
+  # --- Helper to build trips quickly ---
+
+  def create_trip(num_days:, activities: [])
+    trip = Trip.create!(
+      title: "Test Trip",
+      city: "Paris",
+      country: "FR",
+      category: "Discovery",
+      user: @user,
+      lat: 48.8566,
+      lon: 2.3522
+    )
+
+    num_days.times do |i|
+      trip.trip_days.create!(title: "Day #{i + 1}", date: Date.today + i)
+    end
+
+    activities.each do |attrs|
+      trip.activities.create!(
+        title: attrs[:title] || "Activity",
+        address: attrs[:address] || "Paris",
+        lat: attrs[:lat],
+        lon: attrs[:lon],
+        main_category: @category,
+        user: @user
+      )
+    end
+
+    trip.reload
+  end
+
+  # --- Edge cases ---
+
+  test "returns failure when trip has no days" do
+    trip = Trip.create!(
+      title: "Empty Trip", city: "Paris", country: "FR",
+      category: "Discovery", user: @user
+    )
+    result = TripClusteringService.new(trip).call
+    assert_not result.success?
+    assert_match(/no days/, result.message)
+  end
+
+  test "returns failure when not enough geolocated activities" do
+    trip = create_trip(num_days: 3, activities: [
+      { title: "A1", lat: 48.86, lon: 2.35 },
+      { title: "A2", lat: 48.87, lon: 2.36 }
+    ])
+    result = TripClusteringService.new(trip).call
+    assert_not result.success?
+    assert_match(/at least 3/, result.message)
+  end
+
+  test "returns failure when all activities lack coordinates" do
+    trip = create_trip(num_days: 2, activities: [
+      { title: "A1", lat: nil, lon: nil },
+      { title: "A2", lat: nil, lon: nil }
+    ])
+    result = TripClusteringService.new(trip).call
+    assert_not result.success?
+  end
+
+  # --- Single day ---
+
+  test "single day optimizes walking order" do
+    trip = create_trip(num_days: 1, activities: [
+      { title: "North", lat: 48.90, lon: 2.35 },
+      { title: "South", lat: 48.82, lon: 2.35 },
+      { title: "Mid",   lat: 48.86, lon: 2.35 }
+    ])
+
+    result = TripClusteringService.new(trip).call
+    assert result.success?
+
+    day = trip.trip_days.first
+    assigned = trip.activities.where(trip_day_id: day.id).order(:index)
+    assert_equal 3, assigned.count
+
+    # All activities should have sequential indices
+    assert_equal [1, 2, 3], assigned.map(&:index)
+  end
+
+  # --- Multi-day clustering ---
+
+  test "clusters activities into correct number of days" do
+    # Two distinct neighborhoods: Montmartre (north) and Latin Quarter (south)
+    trip = create_trip(num_days: 2, activities: [
+      { title: "Sacre Coeur",   lat: 48.8867, lon: 2.3431 },
+      { title: "Moulin Rouge",  lat: 48.8841, lon: 2.3323 },
+      { title: "Place du Tertre", lat: 48.8863, lon: 2.3408 },
+      { title: "Pantheon",      lat: 48.8462, lon: 2.3464 },
+      { title: "Luxembourg",    lat: 48.8462, lon: 2.3372 },
+      { title: "Notre Dame",    lat: 48.8530, lon: 2.3499 }
+    ])
+
+    result = TripClusteringService.new(trip).call
+    assert result.success?
+
+    trip.trip_days.each do |day|
+      day_activities = trip.activities.where(trip_day_id: day.id)
+      assert day_activities.count > 0, "Day #{day.title} should have activities"
+    end
+
+    # Total activities assigned should match
+    total_assigned = trip.activities.where.not(trip_day_id: nil).count
+    assert_equal 6, total_assigned
+  end
+
+  test "activities within a day are geographically ordered" do
+    trip = create_trip(num_days: 1, activities: [
+      { title: "Far East",   lat: 48.85, lon: 2.40 },
+      { title: "Far West",   lat: 48.85, lon: 2.25 },
+      { title: "Mid East",   lat: 48.85, lon: 2.36 },
+      { title: "Mid West",   lat: 48.85, lon: 2.30 }
+    ])
+
+    result = TripClusteringService.new(trip).call
+    assert result.success?
+
+    ordered = trip.activities.where(trip_day_id: trip.trip_days.first.id).order(:index)
+    # Check that total route distance is reasonable (not random order)
+    # The optimized route should visit nearby activities consecutively
+    lons = ordered.map(&:lon)
+    # After optimization, should be monotonically increasing or decreasing (a line of points)
+    diffs = lons.each_cons(2).map { |a, b| b - a }
+    assert(diffs.all? { |d| d >= 0 } || diffs.all? { |d| d <= 0 },
+      "Activities along a line should be ordered sequentially, got lons: #{lons}")
+  end
+
+  # --- Ungeolocated activities ---
+
+  test "ungeolocated activities are distributed across days" do
+    trip = create_trip(num_days: 2, activities: [
+      { title: "Geo1", lat: 48.86, lon: 2.35 },
+      { title: "Geo2", lat: 48.87, lon: 2.36 },
+      { title: "Geo3", lat: 48.80, lon: 2.30 },
+      { title: "Geo4", lat: 48.81, lon: 2.31 },
+      { title: "NoGeo1", lat: nil, lon: nil },
+      { title: "NoGeo2", lat: nil, lon: nil }
+    ])
+
+    result = TripClusteringService.new(trip).call
+    assert result.success?
+
+    total_assigned = trip.activities.where.not(trip_day_id: nil).count
+    assert_equal 6, total_assigned
+  end
+
+  # --- Haversine distance ---
+
+  test "haversine distance is accurate" do
+    service = TripClusteringService.new(nil)
+    # Paris to London is ~344 km
+    dist = service.send(:haversine, 48.8566, 2.3522, 51.5074, -0.1278)
+    assert_in_delta 344, dist, 5, "Paris-London distance should be ~344 km"
+  end
+
+  # --- Works with many activities (performance) ---
+
+  test "handles 20 activities without timeout" do
+    activities = 20.times.map do |i|
+      { title: "Act#{i}", lat: 48.83 + (i * 0.005), lon: 2.30 + (i * 0.005) }
+    end
+
+    trip = create_trip(num_days: 4, activities: activities)
+
+    start_time = Time.now
+    result = TripClusteringService.new(trip).call
+    elapsed = Time.now - start_time
+
+    assert result.success?
+    assert elapsed < 5, "Should complete in under 5 seconds, took #{elapsed}s"
+
+    # All activities assigned
+    total_assigned = trip.activities.where.not(trip_day_id: nil).count
+    assert_equal 20, total_assigned
+  end
+
+  # --- Uses actual trip day count, not hardcoded ---
+
+  test "works with 5 days" do
+    activities = 10.times.map do |i|
+      { title: "Act#{i}", lat: 48.83 + (i * 0.01), lon: 2.30 + (i * 0.01) }
+    end
+
+    trip = create_trip(num_days: 5, activities: activities)
+    result = TripClusteringService.new(trip).call
+    assert result.success?
+
+    days_with_activities = trip.trip_days.select { |d| trip.activities.where(trip_day_id: d.id).any? }
+    assert_equal 5, days_with_activities.count, "All 5 days should have activities"
+  end
+
+  test "indices are sequential within each day" do
+    activities = 9.times.map do |i|
+      { title: "Act#{i}", lat: 48.83 + (i * 0.005), lon: 2.30 + (i * 0.005) }
+    end
+    trip = create_trip(num_days: 3, activities: activities)
+
+    result = TripClusteringService.new(trip).call
+    assert result.success?
+
+    trip.trip_days.each do |day|
+      indices = trip.activities.where(trip_day_id: day.id).order(:index).pluck(:index)
+      next if indices.empty?
+      assert_equal (1..indices.length).to_a, indices,
+        "Indices should be sequential starting from 1 for #{day.title}"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- **Replace brute-force algorithm** with DBSCAN clustering + nearest-neighbor TSP + 2-opt route optimization, extracted into `TripClusteringService`
- **Fix all major issues**: hardcoded 3-day limit, combinatorial explosion above ~12 activities, incorrect Euclidean distance, N+1 queries
- **Fix Cloudinary initializer** to use the `CLOUDINARY_URL` env var that's actually configured

## What changed

| Before | After |
|--------|-------|
| Hardcoded to 3 days | Uses actual trip day count |
| Combinatorial explosion (unusable >12 activities) | O(n²) DBSCAN — handles 20+ activities in <5s |
| Euclidean distance on lat/lon | Haversine (accurate at any latitude) |
| N+1 queries in a loop | Single eager load + bulk transaction |
| Required `days × 3` activities | Only requires 1 geolocated activity per day |
| No route optimization | Nearest-neighbor + 2-opt within each day |
| ~100 lines of algorithm in controller | 7-line controller action + service object |

## Test plan
- [x] `bin/rails test` — all 18 tests pass (11 new + 7 existing)
- [ ] Manual: create a trip with 10+ activities across different neighborhoods, run "Make My Day", verify activities are grouped by area with sensible walking order

🤖 Generated with [Claude Code](https://claude.com/claude-code)