### PR TITLE
Improve Make My Day algorithm & guest trip playground

### DIFF
--- a/STORIES.md
+++ b/STORIES.md
@@ -76,10 +76,10 @@
 - Essential for participants feature
 - **Priority**: Medium
 
-### B2. Fix N+1 Queries
-- Use `includes(:trip_day)` for eager loading
-- Profile and optimize slow queries
-- **Priority**: Medium
+### B2. ~~Fix N+1 Queries~~ ✅ Done
+- Eager loading via `includes(trip_days: { activities: :main_category })` in `set_trip`
+- Replaced all Ruby `.sort` with SQL `order` scopes on associations
+- Refactored `my_trips` to single query
 
 ### B3. API Endpoints for AJAX
 - Proper JSON API for activities CRUD
@@ -104,6 +104,85 @@
 - Useful for collaboration and accountability
 - Consider: Activity created, moved, edited, deleted
 - **Priority**: Medium
+
+---
+
+## Backlog - Trip Show Page (`/trips/:id`)
+
+### T1. Banner & Hero Section
+- Add dark gradient overlay for text readability on any photo
+- Display trip dates, category, and activity count in the hero
+- Show author avatar next to "By: username"
+- **Priority**: Medium
+
+### T2. Sticky Day Tabs Navigation
+- Add sticky tabs at top to navigate between days without scrolling
+- Show badge with activity count per day
+- **Priority**: Medium
+
+### T3. Empty State Improvement
+- Replace bare "No activities yet" with illustration/icon
+- Add CTA "Start planning this day" for owner, neutral message for visitors
+- **Priority**: Low
+
+### T4. Interactive Map
+- Replace static map image with interactive Google Maps (gmaps4rails already available)
+- Show route/itinerary between activities of the same day
+- Clickable pins linking to activity cards
+- **Priority**: High
+
+### T5. Timeline Enhancements
+- Add estimated times and travel duration between activities
+- Add Google Maps directions link between consecutive activities
+- **Priority**: Medium
+
+### T6. Enable Share Button
+- Uncomment existing share button (currently commented out in show.html.erb)
+- Implement `navigator.share` API with fallback to copy-link
+- **Priority**: Low
+
+### T7. Responsive Layout Fix
+- `col-md-6` causes unbalanced layout on 3-day trips (2+1)
+- Consider full-width per day or carousel/swiper
+- **Priority**: Low
+
+### T8. SEO & Open Graph Meta Tags
+- Add OG meta tags (title, description, image) for social media previews
+- **Priority**: Medium
+
+### T9. Unassigned Activities Card Redesign
+- Current `col-md-3` cards are too small
+- Switch to `col-md-4` or horizontal list layout with larger photos
+- **Priority**: Low
+
+---
+
+## Backlog - Backend (General)
+
+### B7. Async Email Delivery
+- `send_trip` uses `deliver_now` which blocks the request
+- Switch to `deliver_later` with Active Job
+- **Priority**: Medium
+
+### B8. Fix `create_trip_days` Multiple Saves
+- Currently calls `@trip.save` on every loop iteration
+- Build all trip_days first, then save once
+- **Priority**: Low
+
+### B9. Fragment Caching
+- Russian doll caching on trip show page (day cards, activity cards)
+- Cache static map URLs (deterministic)
+- **Priority**: Low
+
+### B10. Trip View Counter
+- Add view counter on public trips (impressionist gem or counter_cache)
+- Useful for ranking popular trips
+- **Priority**: Low
+
+### B11. JSON API for Trip Show
+- Add jbuilder/jsonapi-serializer for trip show endpoint
+- Prepares for future frontend modernization (React/Vue/Turbo)
+- **Priority**: Low
 
 ---
 

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -1,6 +1,9 @@
 class ActivitiesController < ApplicationController
+  include GuestTripAccess
+
+  skip_before_action :authenticate_user!, only: [:create, :update, :destroy, :change_position]
+  before_action :authenticate_user_or_guest!, only: [:create, :update, :destroy, :change_position]
   before_action :set_activity, only: [:show, :edit, :update, :destroy, :change_position, :pin]
-  # before_action :set_trip, only: [:new, :create]
   before_action :sanitize_activity_params, only: [:change_position]
 
 
@@ -26,10 +29,14 @@ class ActivitiesController < ApplicationController
   end
 
   def create
-    @activity = current_user.activities.build(activity_params)
+    if user_signed_in?
+      @activity = current_user.activities.build(activity_params)
+    else
+      @activity = Activity.new(activity_params)
+    end
     p activity_params
     @activity.index = 1 # TODO : REMOVE THIS
-    authorize @activity
+    authorize_or_skip_for_guest!(@activity)
     set_title if @activity.title.nil?
     find_main_category unless (@activity.google_category.nil? || !@activity.main_category.nil?)
     if !params["trip_id"].nil?
@@ -86,13 +93,6 @@ class ActivitiesController < ApplicationController
   end
 
   def pin
-    # @pinned_activity = current_user.pinned_activities.build(activity_id: params["id"])
-    # if @pinned_activity.save
-    #   respond_to do |format|
-    #     format.html { redirect_to :back, notice: 'Activity saved.' }
-    #     format.js  # <-- TODO: will render `app/views/reviews/pin.js.erb`
-    #   end
-    # end
   end
 
   def destroy
@@ -146,7 +146,7 @@ class ActivitiesController < ApplicationController
 
   def set_activity
     @activity = Activity.find(params[:id])
-    authorize @activity
+    authorize_or_skip_for_guest!(@activity)
   end
 
   def set_trip

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   include Pundit
+  include PendingTripCreation
 
   # Pundit: white-list approach.
   after_action :verify_authorized, except: :index, unless: :skip_pundit?
@@ -54,8 +55,10 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_in_path_for(resource)
-    # binding.pry
-    # current_user_path
+    if session[:pending_trip].present?
+      trip = create_pending_trip_for_user(resource)
+      return edit_trip_path(trip) if trip
+    end
     my_trips_path
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,6 +55,10 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_in_path_for(resource)
+    if session[:claimed_trip_id].present?
+      trip = claim_trip_for_user(resource)
+      return edit_trip_path(trip) if trip
+    end
     if session[:pending_trip].present?
       trip = create_pending_trip_for_user(resource)
       return edit_trip_path(trip) if trip

--- a/app/controllers/concerns/guest_trip_access.rb
+++ b/app/controllers/concerns/guest_trip_access.rb
@@ -1,0 +1,42 @@
+module GuestTripAccess
+  extend ActiveSupport::Concern
+
+  private
+
+  def guest_trip_access?(trip)
+    trip.claim_token.present? &&
+      session[:claim_token].present? &&
+      session[:claim_token] == trip.claim_token
+  end
+
+  def authenticate_user_or_guest!
+    return if user_signed_in?
+
+    trip = find_trip_for_guest_check
+    return if trip && guest_trip_access?(trip)
+
+    authenticate_user!
+  end
+
+  def authorize_or_skip_for_guest!(record, query = nil)
+    if user_signed_in?
+      authorize record, query
+    elsif guest_trip_access?(record.is_a?(Trip) ? record : record.trip)
+      skip_authorization
+    else
+      raise Pundit::NotAuthorizedError
+    end
+  end
+
+  def find_trip_for_guest_check
+    if params[:id] && controller_name == "trips"
+      Trip.find_by(id: params[:id])
+    elsif params[:trip_id]
+      Trip.find_by(id: params[:trip_id])
+    elsif params[:activity] && params[:activity][:trip_id]
+      Trip.find_by(id: params[:activity][:trip_id])
+    elsif params[:id] && controller_name == "activities"
+      Activity.find_by(id: params[:id])&.trip
+    end
+  end
+end

--- a/app/controllers/concerns/pending_trip_creation.rb
+++ b/app/controllers/concerns/pending_trip_creation.rb
@@ -1,0 +1,47 @@
+module PendingTripCreation
+  extend ActiveSupport::Concern
+
+  def create_pending_trip_for_user(user)
+    return nil unless session[:pending_trip].present?
+
+    trip_params = session[:pending_trip].except("nb_days", "start_date", "invite_emails")
+    trip = user.trips.build(trip_params.permit!)
+
+    nb_days = (session[:pending_trip]["nb_days"].to_i.zero? ? 3 : session[:pending_trip]["nb_days"].to_i)
+    start_date = session[:pending_trip]["start_date"].present? ? Date.parse(session[:pending_trip]["start_date"]) : Date.today
+
+    day = start_date
+    [nb_days, 3].max.times do
+      trip.trip_days.build(title: day.strftime('%A'), date: day)
+      day = day.next
+    end
+
+    if trip.save
+      process_pending_invites(trip, user, session[:pending_trip]["invite_emails"])
+      session.delete(:pending_trip)
+      trip
+    else
+      session.delete(:pending_trip)
+      nil
+    end
+  end
+
+  private
+
+  def process_pending_invites(trip, user, emails_string)
+    return if emails_string.blank?
+
+    emails = emails_string.split(",").map(&:strip).reject(&:blank?)
+    emails.each do |email|
+      invite = trip.invites.build(email: email, sender_id: user.id)
+      if invite.save
+        if invite.recipient.present?
+          InviteMailer.existing_user_invite(invite).deliver_later
+          invite.recipient.participants.create(trip: trip, role: "Editor")
+        else
+          InviteMailer.new_user_invite(invite, new_user_registration_url(invite_token: invite.token)).deliver_later
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/pending_trip_creation.rb
+++ b/app/controllers/concerns/pending_trip_creation.rb
@@ -1,6 +1,23 @@
 module PendingTripCreation
   extend ActiveSupport::Concern
 
+  def claim_trip_for_user(user)
+    return nil unless session[:claimed_trip_id].present? && session[:claim_token].present?
+
+    trip = Trip.find_by(id: session[:claimed_trip_id], claim_token: session[:claim_token])
+    return nil unless trip
+
+    trip.user = user
+    trip.claim_token = nil
+    trip.save!
+
+    trip.activities.where(user_id: nil).update_all(user_id: user.id)
+
+    session.delete(:claimed_trip_id)
+    session.delete(:claim_token)
+    trip
+  end
+
   def create_pending_trip_for_user(user)
     return nil unless session[:pending_trip].present?
 
@@ -11,7 +28,7 @@ module PendingTripCreation
     start_date = session[:pending_trip]["start_date"].present? ? Date.parse(session[:pending_trip]["start_date"]) : Date.today
 
     day = start_date
-    [nb_days, 3].max.times do
+    [nb_days, 1].max.times do
       trip.trip_days.build(title: day.strftime('%A'), date: day)
       day = day.next
     end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,8 +4,9 @@ class PagesController < ApplicationController
 
   def home
     @trips = policy_scope(Trip)
-    @trips = @trips.sort { |x, y| y.likes <=> x.likes }
-    @trips = @trips.first(4)
+              .includes(:user, :activities)
+              .order(cached_votes_total: :desc)
+              .limit(4)
   end
 
   def unsplash_photo

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,4 +1,5 @@
 class RegistrationsController < Devise::RegistrationsController
+  include PendingTripCreation
 
   def new
     @token = params[:invite_token]
@@ -18,6 +19,14 @@ class RegistrationsController < Devise::RegistrationsController
         end
       end
     end
+  end
+
+  def after_sign_up_path_for(resource)
+    if session[:pending_trip].present?
+      trip = create_pending_trip_for_user(resource)
+      return edit_trip_path(trip) if trip
+    end
+    my_trips_path
   end
 
   private

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -22,6 +22,10 @@ class RegistrationsController < Devise::RegistrationsController
   end
 
   def after_sign_up_path_for(resource)
+    if session[:claimed_trip_id].present?
+      trip = claim_trip_for_user(resource)
+      return edit_trip_path(trip) if trip
+    end
     if session[:pending_trip].present?
       trip = create_pending_trip_for_user(resource)
       return edit_trip_path(trip) if trip

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -1,6 +1,8 @@
 # Trip controller - classic CRUD so far
 class TripsController < ApplicationController
-  skip_before_action :authenticate_user!, only: [:index, :show, :send_trip, :search, :new, :create]
+  include GuestTripAccess
+
+  skip_before_action :authenticate_user!, only: [:index, :show, :send_trip, :search, :new, :create, :edit, :map_markers]
   before_action :set_trip, only: [:show, :send_trip, :edit, :update, :destroy, :like, :make_my_day, :map_markers, :properties]
 
   skip_after_action :verify_authorized, only: [:my_trips, :search]
@@ -55,8 +57,10 @@ class TripsController < ApplicationController
   end
 
   def edit
+    authenticate_user_or_guest!
     @activity = Activity.new
     @main_categories = MainCategory.all
+    @unclaimed = @trip.claim_token.present?
   end
 
   def properties
@@ -77,17 +81,20 @@ class TripsController < ApplicationController
         render :new
       end
     else
-      # Guest flow: validate, store in session, redirect to sign up
+      # Guest flow: create real trip in DB with no user
       @trip = Trip.new(trip_params)
+      @trip.public = false
       authorize @trip
-      @trip.user = User.new # temp user to pass belongs_to validation
       if @trip.valid?
-        pending = params[:trip].to_unsafe_h.except("photo", "photo_cache")
-        pending["nb_days"] = params["trip"]["nb_days"]
-        pending["start_date"] = params["trip"]["start_date"]
-        pending["invite_emails"] = params[:invite_emails]
-        session[:pending_trip] = pending
-        redirect_to new_user_registration_path, notice: "Sign up to save your trip!"
+        params["trip"]["nb_days"].to_i == 0 ? nb_days = 3 : nb_days = params["trip"]["nb_days"].to_i
+        create_trip_days(nb_days, params["trip"]["start_date"].to_date)
+        if @trip.save
+          session[:claim_token] = @trip.claim_token
+          session[:claimed_trip_id] = @trip.id
+          redirect_to edit_trip_path(@trip), notice: 'Trip created! Sign up anytime to save it.'
+        else
+          render :new
+        end
       else
         render :new
       end
@@ -96,7 +103,7 @@ class TripsController < ApplicationController
 
   def create_trip_days(nb_days, start_date)
     day = start_date || Date.today
-    days = [nb_days, 3].max
+    days = [nb_days, 1].max
     days.times do
       @trip.trip_days.build(title: day.strftime('%A'), date: day)
       @trip.save
@@ -135,6 +142,7 @@ class TripsController < ApplicationController
   end
 
   def map_markers
+    authenticate_user_or_guest!
     respond_to do |format|
       format.json
     end
@@ -145,7 +153,7 @@ class TripsController < ApplicationController
   def set_trip
     @trip = Trip.includes(trip_days: { activities: :main_category }, activities: :main_category)
                .find(params[:id])
-    authorize @trip
+    authorize_or_skip_for_guest!(@trip)
   end
 
   def trip_params

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -1,32 +1,33 @@
 # Trip controller - classic CRUD so far
 class TripsController < ApplicationController
-  skip_before_action :authenticate_user!, only: [:index, :show, :send_trip, :search ]
+  skip_before_action :authenticate_user!, only: [:index, :show, :send_trip, :search, :new, :create]
   before_action :set_trip, only: [:show, :send_trip, :edit, :update, :destroy, :like, :make_my_day, :map_markers, :properties]
 
   skip_after_action :verify_authorized, only: [:my_trips, :search]
 
   def index
-    # @trips = Trip.all
     @trips = policy_scope(Trip)
-    @trips = @trips.sort { |x, y| y.activities.count <=> x.activities.count }
-    @trips = @trips.sort { |x, y| y.cached_votes_total <=> x.cached_votes_total }
+              .includes(:user, :activities)
+              .left_joins(:activities)
+              .group("trips.id")
+              .order("cached_votes_total DESC, COUNT(activities.id) DESC")
   end
 
   def search
     @trips = policy_scope(Trip)
-    @trips = @trips.near(params["trip"]["city"], 100)
-    @trips = @trips.sort { |x, y| y.activities.count <=> x.activities.count }
-    @trips = @trips.sort { |x, y| y.cached_votes_total <=> x.cached_votes_total }
+              .near(params["trip"]["city"], 100)
+              .includes(:user, :activities)
+              .left_joins(:activities)
+              .group("trips.id")
+              .order("cached_votes_total DESC, COUNT(activities.id) DESC")
     render :index
   end
 
   def my_trips
-    @trips = []
-    @trips += current_user.trips
-    current_user.participants.each do |participation|
-      @trips << participation.trip unless @trips.include?(participation.trip)
-    end
-    @trips += current_user.find_voted_items
+    trip_ids = current_user.trip_ids +
+               current_user.participants.pluck(:trip_id) +
+               current_user.find_voted_items.map(&:id)
+    @trips = Trip.where(id: trip_ids.uniq).includes(:user, :activities)
   end
 
   def show
@@ -63,16 +64,33 @@ class TripsController < ApplicationController
   end
 
   def create
-    @trip = current_user.trips.build(trip_params)
-    authorize @trip
-    params["trip"]["nb_days"].to_i == 0 ? nb_days = 3 : nb_days = params["trip"]["nb_days"].to_i
-    create_trip_days(nb_days, params["trip"]["start_date"].to_date)
-    if @trip.save
-      # Process invite emails if provided
-      process_invite_emails if params[:invite_emails].present?
-      redirect_to edit_trip_path(@trip), notice: 'Trip was successfully created.'
+    if user_signed_in?
+      @trip = current_user.trips.build(trip_params)
+      authorize @trip
+      params["trip"]["nb_days"].to_i == 0 ? nb_days = 3 : nb_days = params["trip"]["nb_days"].to_i
+      create_trip_days(nb_days, params["trip"]["start_date"].to_date)
+      if @trip.save
+        # Process invite emails if provided
+        process_invite_emails if params[:invite_emails].present?
+        redirect_to edit_trip_path(@trip), notice: 'Trip was successfully created.'
+      else
+        render :new
+      end
     else
-      render :new
+      # Guest flow: validate, store in session, redirect to sign up
+      @trip = Trip.new(trip_params)
+      authorize @trip
+      @trip.user = User.new # temp user to pass belongs_to validation
+      if @trip.valid?
+        pending = params[:trip].to_unsafe_h.except("photo", "photo_cache")
+        pending["nb_days"] = params["trip"]["nb_days"]
+        pending["start_date"] = params["trip"]["start_date"]
+        pending["invite_emails"] = params[:invite_emails]
+        session[:pending_trip] = pending
+        redirect_to new_user_registration_path, notice: "Sign up to save your trip!"
+      else
+        render :new
+      end
     end
   end
 
@@ -125,7 +143,8 @@ class TripsController < ApplicationController
   private
 
   def set_trip
-    @trip = Trip.find(params[:id])
+    @trip = Trip.includes(trip_days: { activities: :main_category }, activities: :main_category)
+               .find(params[:id])
     authorize @trip
   end
 

--- a/app/jobs/cleanup_unclaimed_trips_job.rb
+++ b/app/jobs/cleanup_unclaimed_trips_job.rb
@@ -1,0 +1,10 @@
+class CleanupUnclaimedTripsJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    trips = Trip.expired_unclaimed
+    count = trips.count
+    trips.destroy_all
+    Rails.logger.info "CleanupUnclaimedTripsJob: Deleted #{count} unclaimed trips older than 30 days"
+  end
+end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -4,7 +4,7 @@ class Activity < ApplicationRecord
   belongs_to :trip
   belongs_to :trip_day, optional: true
   belongs_to :main_category
-  belongs_to :user
+  belongs_to :user, optional: true
 
   has_many :pinned_activities, dependent: :destroy
 

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -2,13 +2,18 @@
 class Trip < ApplicationRecord
   acts_as_votable
 
-  belongs_to :user
+  belongs_to :user, optional: true
   has_many :trip_days, -> { order "created_at ASC" }, dependent: :destroy
   has_many :activities, -> { order(:index) }, dependent: :destroy
   has_many :participants
   has_many :invites
 
   attr_accessor :nb_days, :start_date
+
+  scope :unclaimed, -> { where.not(claim_token: nil) }
+  scope :expired_unclaimed, -> { unclaimed.where("trips.created_at < ?", 30.days.ago) }
+
+  before_create :generate_claim_token, if: -> { user_id.nil? }
 
   validates :title, presence: true
   validates :city, presence: true
@@ -63,4 +68,9 @@ class Trip < ApplicationRecord
     self.votes_for.size
   end
 
+  private
+
+  def generate_claim_token
+    self.claim_token = SecureRandom.hex(20)
+  end
 end

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -4,7 +4,7 @@ class Trip < ApplicationRecord
 
   belongs_to :user
   has_many :trip_days, -> { order "created_at ASC" }, dependent: :destroy
-  has_many :activities, dependent: :destroy
+  has_many :activities, -> { order(:index) }, dependent: :destroy
   has_many :participants
   has_many :invites
 

--- a/app/models/trip_day.rb
+++ b/app/models/trip_day.rb
@@ -1,7 +1,7 @@
 # days belonging to trips to which we assign activities when sorting them out
 class TripDay < ApplicationRecord
   belongs_to :trip
-  has_many :activities, dependent: :destroy
+  has_many :activities, -> { order(:index) }, dependent: :destroy
 
   def panel_id
     self.title.downcase.gsub(' ', '_')
@@ -13,7 +13,7 @@ class TripDay < ApplicationRecord
     key = "&key=" + ENV['GOOGLE_API_BROWSER_KEY']
     markers = ""
     path = "&path=color:0x0000ff70%7Cweight:3"
-    sorted_activities = self.activities.where.not(lat: nil, lon: nil).sort { |x, y| x.index <=> y.index }
+    sorted_activities = self.activities.where.not(lat: nil, lon: nil).order(:index)
     sorted_activities.each do |act|
       m_color = color_code(act.main_category.color)
       markers += "&markers=color:#{m_color}%7Clabel:#{act.index.to_s}%7C#{act.lat},#{act.lon}"

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -40,9 +40,7 @@ class ActivityPolicy < ApplicationPolicy
   end
 
   def user_is_owner_or_admin?
-    # TODO: seul le user peut modifier le resto
-    # record => @trip
-    # user => current_user
+    return false unless user
     user.admin || record.user == user || record.trip.user == user
   end
 

--- a/app/views/activities/create.js.erb
+++ b/app/views/activities/create.js.erb
@@ -30,4 +30,14 @@ console.log('error')
   $('#activity_est_lon').val('');
 
   $('#autoRefresh').click();
+
+  <% if @activity.trip&.claim_token.present? && @activity.trip.activities.count >= 3 %>
+    // Soft nudge for guest users
+    var nudgeToast = $('<div class="save-toast success" style="background: #f0ad4e; color: #fff;">' +
+      '<span>You\'ve added <%= @activity.trip.activities.count %> activities! ' +
+      '<a href="<%= new_user_registration_path %>" style="color: #fff; text-decoration: underline; font-weight: bold;">Sign up</a> to save your progress.</span>' +
+      '</div>');
+    $('body').append(nudgeToast);
+    setTimeout(function() { nudgeToast.fadeOut(300, function() { $(this).remove(); }); }, 5000);
+  <% end %>
 <% end %>

--- a/app/views/trips/_card_trip_day_show.html.erb
+++ b/app/views/trips/_card_trip_day_show.html.erb
@@ -8,7 +8,7 @@
     <div class="text-center">
       <img src="<%= tripday.static_map_url(500, 500) %>"></img>
       <ul class="timeline">
-        <% tripday.activities.sort{ |x, y| x.index <=> y.index }.each_with_index do |activity, index| %>
+        <% tripday.activities.each_with_index do |activity, index| %>
           <li class="<%= 'timeline-inverted' if index % 2 != 0 %>">
             <div class="timeline-badge">
               <%= image_tag(activity.main_category.icon, class: 'icones') %>

--- a/app/views/trips/edit.html.erb
+++ b/app/views/trips/edit.html.erb
@@ -4,6 +4,14 @@
 <% @disable_footer = true %>
 <% trip_icons = set_day_icon(@trip.trip_days) %>
 <div class="trip-edit-wrapper">
+  <% if @unclaimed %>
+    <div class="alert alert-warning alert-dismissible guest-trip-banner" role="alert" style="margin-bottom: 0; border-radius: 0; text-align: center; position: relative; z-index: 10;">
+      <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+      <strong>You're trying out Yalla!</strong> Sign up to save your trip and keep planning.
+      <%= link_to "Sign Up", new_user_registration_path, class: "btn btn-success btn-sm", style: "margin-left: 10px;" %>
+      <%= link_to "Sign In", new_user_session_path, class: "btn btn-default btn-sm", style: "margin-left: 5px;" %>
+    </div>
+  <% end %>
   <!-- Mobile Tab Navigation -->
   <div class="mobile-tabs">
     <button class="mobile-tab active" data-tab="plan-panel">

--- a/app/views/trips/new.html.erb
+++ b/app/views/trips/new.html.erb
@@ -50,20 +50,22 @@
               </div>
 
               <!-- Invite Friends -->
-              <div class="form-section">
-                <div class="form-group invite-friends-group">
-                  <label class="control-label">Invite friends</label>
-                  <div class="invite-input-wrapper">
-                    <div class="email-chips" id="email-chips"></div>
-                    <input type="email"
-                           id="invite-email-input"
-                           class="form-control"
-                           placeholder="Enter email and press Enter">
+              <% if user_signed_in? %>
+                <div class="form-section">
+                  <div class="form-group invite-friends-group">
+                    <label class="control-label">Invite friends</label>
+                    <div class="invite-input-wrapper">
+                      <div class="email-chips" id="email-chips"></div>
+                      <input type="email"
+                             id="invite-email-input"
+                             class="form-control"
+                             placeholder="Enter email and press Enter">
+                    </div>
+                    <input type="hidden" name="invite_emails" id="invite-emails-hidden" value="">
+                    <p class="help-block">Invite collaborators to help plan this trip</p>
                   </div>
-                  <input type="hidden" name="invite_emails" id="invite-emails-hidden" value="">
-                  <p class="help-block">Invite collaborators to help plan this trip</p>
                 </div>
-              </div>
+              <% end %>
 
               <!-- Cover Photo -->
               <div class="form-section">

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -98,7 +98,7 @@
   <div class="row noassigned">
     <h3 class="text-center">Other activities unassigned</h3>
     <div class="mini-padded"></div>
-        <% @trip.activities.where(trip_day_id: nil).sort{ |x, y| x.index <=> y.index }.each do |activity| %>
+        <% @trip.activities.where(trip_day_id: nil).order(:index).each do |activity| %>
           <%= render 'card_noassigned', activity:activity %>
       <% end %>
     <div class="padded"></div>

--- a/db/migrate/20260219124140_add_claim_token_to_trips.rb
+++ b/db/migrate/20260219124140_add_claim_token_to_trips.rb
@@ -1,0 +1,6 @@
+class AddClaimTokenToTrips < ActiveRecord::Migration[7.1]
+  def change
+    add_column :trips, :claim_token, :string
+    add_index :trips, :claim_token, unique: true, where: "claim_token IS NOT NULL"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2016_12_14_204527) do
+ActiveRecord::Schema[7.1].define(version: 2026_02_19_124140) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -116,6 +116,7 @@ ActiveRecord::Schema[7.1].define(version: 2016_12_14_204527) do
     t.integer "cached_weighted_score", default: 0
     t.integer "cached_weighted_total", default: 0
     t.float "cached_weighted_average", default: 0.0
+    t.string "claim_token"
     t.index ["cached_votes_down"], name: "index_trips_on_cached_votes_down"
     t.index ["cached_votes_score"], name: "index_trips_on_cached_votes_score"
     t.index ["cached_votes_total"], name: "index_trips_on_cached_votes_total"
@@ -123,6 +124,7 @@ ActiveRecord::Schema[7.1].define(version: 2016_12_14_204527) do
     t.index ["cached_weighted_average"], name: "index_trips_on_cached_weighted_average"
     t.index ["cached_weighted_score"], name: "index_trips_on_cached_weighted_score"
     t.index ["cached_weighted_total"], name: "index_trips_on_cached_weighted_total"
+    t.index ["claim_token"], name: "index_trips_on_claim_token", unique: true, where: "(claim_token IS NOT NULL)"
     t.index ["user_id"], name: "index_trips_on_user_id"
   end
 

--- a/lib/tasks/trips.rake
+++ b/lib/tasks/trips.rake
@@ -130,6 +130,11 @@ namespace :trips do
     puts "=" * 50
   end
 
+  desc "Clean up unclaimed guest trips older than 30 days"
+  task cleanup_unclaimed: :environment do
+    CleanupUnclaimedTripsJob.perform_now
+  end
+
   desc "List trips missing photos"
   task missing_photos: :environment do
     trips_without_photos = Trip.where(photo: [nil, ''])


### PR DESCRIPTION
## Summary
- **Make My Day rework**: Replaced brute-force algorithm with DBSCAN clustering + TSP for smarter itinerary optimization
- **Guest trip playground**: Guests can now use the full edit page (add activities, drag & drop, map) before signing up. Trips are created in the DB with a `claim_token` and claimed on sign-up/sign-in
- **N+1 query fixes**: Replaced Ruby sort with SQL ordering, added eager loading
- **Cloudinary fix**: Updated initializer to use `CLOUDINARY_URL` env var
- **Trip day flexibility**: Removed forced minimum of 3 days — respects user input

## Guest trip flow
1. Guest fills out trip form → trip created in DB with `user_id: nil` and auto-generated `claim_token`
2. Guest lands on `/trips/:id/edit` with a banner prompting sign-up
3. After 3 activities, a soft nudge toast suggests signing up
4. On sign-up/sign-in, the trip is claimed (user_id set, claim_token cleared)
5. Guest trips are private by default; unclaimed trips cleaned up after 30 days via rake task

## Test plan
- [ ] Verify Make My Day produces sensible day clusters
- [ ] Log out → create trip as guest → lands on edit page with banner
- [ ] Add activities, drag & drop as guest → all work
- [ ] After 3rd activity → nudge toast appears
- [ ] Sign up → trip claimed, banner gone, user_id set on trip + activities
- [ ] Sign in (instead of sign up) → same claim behavior
- [ ] Visit unclaimed trip URL without session token → denied
- [ ] `rake trips:cleanup_unclaimed` → deletes old unclaimed trips
- [ ] Existing logged-in user flow unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)