### PR TITLE
Fix public trips inaccessible when logged out

### DIFF
--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -3,7 +3,8 @@ class TripsController < ApplicationController
   include GuestTripAccess
 
   skip_before_action :authenticate_user!, only: [:index, :show, :send_trip, :search, :new, :create, :edit, :map_markers]
-  before_action :set_trip, only: [:show, :send_trip, :edit, :update, :destroy, :like, :make_my_day, :map_markers, :properties]
+  before_action :set_trip, only: [:show, :send_trip, :like, :update, :destroy, :make_my_day, :properties]
+  before_action :set_trip_for_guest, only: [:edit, :map_markers]
 
   skip_after_action :verify_authorized, only: [:my_trips, :search]
 
@@ -151,6 +152,12 @@ class TripsController < ApplicationController
   private
 
   def set_trip
+    @trip = Trip.includes(trip_days: { activities: :main_category }, activities: :main_category)
+               .find(params[:id])
+    authorize @trip
+  end
+
+  def set_trip_for_guest
     @trip = Trip.includes(trip_days: { activities: :main_category }, activities: :main_category)
                .find(params[:id])
     authorize_or_skip_for_guest!(@trip)


### PR DESCRIPTION
## Summary
- Guest trip authorization was blocking logged-out users from viewing public trip pages
- Split `set_trip` into two callbacks: regular `authorize` for public actions (show, like, etc.) and `authorize_or_skip_for_guest!` only for edit/map_markers

## Test plan
- [ ] Visit a public trip page while logged out → should work
- [ ] Guest edit flow still works with claim_token
- [ ] Logged-in users can still view/edit their trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)